### PR TITLE
updateCollection was broken when both set array and condition array were given

### DIFF
--- a/xpdo/om/mysql/xpdoquery.class.php
+++ b/xpdo/om/mysql/xpdoquery.class.php
@@ -105,7 +105,7 @@ class xPDOQuery_mysql extends xPDOQuery {
                     $clauses[] = $this->xpdo->escape($setKey) . ' = ' . $value;
                 }
                 if (!empty($clauses)) {
-                    $sql.= 'SET ' . implode(', ', $clauses);
+                    $sql.= 'SET ' . implode(', ', $clauses) . ' ';
                 }
                 unset($clauses);
             }

--- a/xpdo/om/sqlite/xpdoquery.class.php
+++ b/xpdo/om/sqlite/xpdoquery.class.php
@@ -105,7 +105,7 @@ class xPDOQuery_sqlite extends xPDOQuery {
                     $clauses[] = $this->xpdo->escape($setKey) . ' = ' . $value;
                 }
                 if (!empty($clauses)) {
-                    $sql.= 'SET ' . implode(', ', $clauses);
+                    $sql.= 'SET ' . implode(', ', $clauses) . ' ';
                 }
                 unset($clauses);
             }

--- a/xpdo/om/sqlsrv/xpdoquery.class.php
+++ b/xpdo/om/sqlsrv/xpdoquery.class.php
@@ -275,7 +275,7 @@ class xPDOQuery_sqlsrv extends xPDOQuery {
                     $clauses[] = $this->xpdo->escape($setKey) . ' = ' . $value;
                 }
                 if (!empty($clauses)) {
-                    $sql.= 'SET ' . implode(', ', $clauses);
+                    $sql.= 'SET ' . implode(', ', $clauses) . ' ';
                 }
                 unset($clauses);
             }


### PR DESCRIPTION
This fix resolves this error:

$this->modx->updateCollection('xyzMeeting',
            array('agent' => 0 ),
            array('agent' => 3)
        );

(ERROR in xPDO::updateCollection @ \core\xpdo\xpdo.class.php : 832) Error updating xyzMeeting instances using query UPDATE `modx_xyz_meeting` SET `agent` = 0WHERE `modx_xyz_meeting`.`agent` = 3 

*\* notice the missing space "0WHERE"
