### PR TITLE
Round decimal

### DIFF
--- a/xpdo/om/xpdoquery.class.php
+++ b/xpdo/om/xpdoquery.class.php
@@ -80,7 +80,7 @@ abstract class xPDOQuery extends xPDOCriteria {
         'MIN(',
         'AVG('
     );
-    protected $_quotable= array ('string', 'password', 'date', 'datetime', 'timestamp', 'time');
+    protected $_quotable= array ('string', 'password', 'date', 'datetime', 'timestamp', 'time', 'float', 'double');
     protected $_class= null;
     protected $_alias= null;
     protected $_tableClass = null;


### PR DESCRIPTION
If datatype float or double, on xPDOQuery->set(array $fields), we got rounded value.

https://github.com/modxcms/xpdo/blob/d4bd6d617b8b755fe7c4784c12ba3e2c1be2a4a6/xpdo/om/xpdoquery.class.php#L236

For example (shopModx Extra required):

print '<pre>';
$q = $this->modx->newQuery('ShopmodxProduct');
$q->command('update');
$q->set(array(
    'sm_price' => 154.99,  
));

if($q->prepare()){  
    print $q->toSQL();
}
