### PR TITLE
Proposal for silent failure validation

### DIFF
--- a/xpdo/transport/xpdofilevehicle.class.php
+++ b/xpdo/transport/xpdofilevehicle.class.php
@@ -107,7 +107,7 @@ class xPDOFileVehicle extends xPDOVehicle {
                     if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not resolve vehicle: ' . print_r($vOptions, true));
                 }
             } else {
-                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle for object: ' . print_r($object, true));
+                //$transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle for object: ' . print_r($object, true));
                 if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not validate vehicle: ' . print_r($vOptions, true));
             }
         }
@@ -170,7 +170,7 @@ class xPDOFileVehicle extends xPDOVehicle {
                     if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not resolve vehicle: ' . print_r($vOptions, true));
                 }
             } else {
-                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle for object: ' . print_r($object, true));
+                //$transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle for object: ' . print_r($object, true));
                 if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not validate vehicle: ' . print_r($vOptions, true));
             }
         }

--- a/xpdo/transport/xpdoobjectvehicle.class.php
+++ b/xpdo/transport/xpdoobjectvehicle.class.php
@@ -351,7 +351,7 @@ class xPDOObjectVehicle extends xPDOVehicle {
                     if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not resolve vehicle: ' . print_r($vOptions, true));
                 }
             } else {
-                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not validate vehicle object of class {$vClass}; criteria: " . print_r($criteria, true));
+                //$transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not validate vehicle object of class {$vClass}; criteria: " . print_r($criteria, true));
                 if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not validate vehicle object: ' . print_r($vOptions, true));
             }
         } else {

--- a/xpdo/transport/xpdoscriptvehicle.class.php
+++ b/xpdo/transport/xpdoscriptvehicle.class.php
@@ -69,7 +69,7 @@ class xPDOScriptVehicle extends xPDOVehicle {
                     if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not resolve vehicle: ' . print_r($vOptions, true));
                 }
             } else {
-                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle for object: ' . print_r($object, true));
+                //$transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle for object: ' . print_r($object, true));
                 if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not validate vehicle: ' . print_r($vOptions, true));
             }
         }

--- a/xpdo/transport/xpdotransportvehicle.class.php
+++ b/xpdo/transport/xpdotransportvehicle.class.php
@@ -105,7 +105,7 @@ class xPDOTransportVehicle extends xPDOVehicle {
                     $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not resolve vehicle: ' . print_r($vOptions, true));
                 }
             } else {
-                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle: ' . print_r($vOptions, true));
+                //$transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle: ' . print_r($vOptions, true));
             }
         } else {
             $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not load vehicle: ' . print_r($vOptions, true));
@@ -135,7 +135,7 @@ class xPDOTransportVehicle extends xPDOVehicle {
                     $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not resolve vehicle: ' . print_r($vOptions, true));
                 }
             } else {
-                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle: ' . print_r($vOptions, true));
+                //$transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not validate vehicle: ' . print_r($vOptions, true));
             }
         } else {
             $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not load vehicle: ' . print_r($vOptions, true));

--- a/xpdo/transport/xpdovehicle.class.php
+++ b/xpdo/transport/xpdovehicle.class.php
@@ -264,7 +264,7 @@ abstract class xPDOVehicle {
                         $fileName = $fileMeta['name'];
                         $fileSource = $transport->path . $fileMeta['source'];
                         if (!$validated = include ($fileSource)) {
-                            if (!isset($fileMeta['silent_fail']) || !$fileMeta['silent_fail']) {
+                            if (isset($fileMeta['verbose']) || $fileMeta['verbose']) {
                                 $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOVehicle validator failed: type php ({$fileSource})");
                             }
                         }


### PR DESCRIPTION
As discussed on IRC, here is a quick proposal to allow validators to silently fail.

``` php
$vehicle->validate('php', array(
    'source' => 'validator.php',
    'silent_fail' => true,
));
```

This proposal has just been made for xPDOOBjectVehicule, but can easily be replicated for the other vehicules if the idea/implementation suits you.
