### PR TITLE
xPDOGenerator & objects attributes

### DIFF
--- a/xpdo/om/xpdogenerator.class.php
+++ b/xpdo/om/xpdogenerator.class.php
@@ -219,6 +219,9 @@ abstract class xPDOGenerator {
                     foreach ($object->attributes() as $objAttrKey => $objAttr) {
                         if ($objAttrKey == 'class') continue;
                         $this->map[$class][$objAttrKey]= (string) $objAttr;
+                        if (!in_array($objAttrKey, array('package', 'version', 'extends', 'table'))) {
+                            $this->classes[$class][$objAttrKey] = (string) $objAttr;
+                        }
                     }
                     $this->map[$class]['fields']= array();
                     $this->map[$class]['fieldMeta']= array();
@@ -619,7 +622,7 @@ abstract class xPDOGenerator {
 
     /**
      * Write the generated meta map to the specified path.
-     * 
+     *
      * @param string $path An absolute path to write the generated maps to.
      * @return bool
      */
@@ -633,7 +636,7 @@ abstract class xPDOGenerator {
             }
         }
         $placeholders = array();
-        
+
         $model= $this->model;
         if (isset($this->model['phpdoc-package'])) {
             $model['phpdoc-package']= '@package ' . $this->model['phpdoc-package'];
@@ -654,7 +657,7 @@ abstract class xPDOGenerator {
             $model['phpdoc-subpackage']= '@subpackage ' . $subpackage;
         }
         $placeholders = array_merge($placeholders,$model);
-        
+
         $classMap = array();
 //        $skipClasses = array('xPDOObject','xPDOSimpleObject');
         foreach ($this->classes as $className => $meta) {


### PR DESCRIPTION
Allow custom object attributes to be used as placeholders in classes templates to help populate the PHPDoc (ie. comments).

As i was not sure about the consequences i added a few attributes as "reserved".

While not fixing them, it's somehow related to #29 & #30