### PR TITLE
Refactored and improved xpdozip class

### DIFF
--- a/xpdo/compression/xpdozip.class.php
+++ b/xpdo/compression/xpdozip.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2010-2013 by MODX, LLC.
+ * Copyright 2010-2014 by MODX, LLC.
  *
  * This file is part of xPDO.
  *
@@ -39,7 +39,7 @@ class xPDOZip {
     const ZIP_TARGET = 'zip_target';
 
     public $xpdo = null;
-    protected $_filename = '';
+    protected $_file = '';
     protected $_options = array();
     protected $_archive = null;
     protected $_errors = array();
@@ -48,34 +48,34 @@ class xPDOZip {
      * Construct an instance representing a specific archive.
      *
      * @param xPDO &$xpdo A reference to an xPDO instance.
-     * @param string $filename The name of the archive the instance will represent.
+     * @param string $file The name of the archive the instance will represent.
      * @param array $options An array of options for this instance.
      */
-    public function __construct(xPDO &$xpdo, $filename, array $options = array()) {
+    public function __construct(xPDO &$xpdo, $file, array $options = array()) {
         $this->xpdo =& $xpdo;
-        $this->_filename = is_string($filename) ? $filename : '';
-        $this->_options = is_array($options) ? $options : array();
+        $this->_options = !empty($options) ? $options : (is_array($file) ? $file : array());
+        $this->_file = is_string($file) ? $file : (isset($this->_options['file']) ? $this->_options['file'] : '');
         $this->_archive = new ZipArchive();
-        if (!empty($this->_filename) && file_exists(dirname($this->_filename))) {
-            if (file_exists($this->_filename)) {
-                if ($this->getOption(xPDOZip::OVERWRITE, null, false) && is_writable($this->_filename)) {
-                    if ($this->_archive->open($this->_filename, ZIPARCHIVE::OVERWRITE) !== true) {
-                        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: Error opening archive at {$this->_filename} for OVERWRITE");
+        if (!empty($this->_file) && file_exists(dirname($this->_file))) {
+            if (file_exists($this->_file)) {
+                if ($this->getOption(xPDOZip::OVERWRITE, null, false) && is_writable($this->_file)) {
+                    if ($this->_archive->open($this->_file, ZIPARCHIVE::OVERWRITE) !== true) {
+                        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: Error opening archive at {$this->_file} for OVERWRITE");
                     }
                 } else {
-                    if ($this->_archive->open($this->_filename) !== true) {
-                        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: Error opening archive at {$this->_filename}");
+                    if ($this->_archive->open($this->_file) !== true) {
+                        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: Error opening archive at {$this->_file}");
                     }
                 }
-            } elseif ($this->getOption(xPDOZip::CREATE, null, false) && is_writable(dirname($this->_filename))) {
-                if ($this->_archive->open($this->_filename, ZIPARCHIVE::CREATE) !== true) {
-                    $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: Could not create archive at {$this->_filename}");
+            } elseif ($this->getOption(xPDOZip::CREATE, null, false) && is_writable(dirname($this->_file))) {
+                if ($this->_archive->open($this->_file, ZIPARCHIVE::CREATE) !== true) {
+                    $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: Could not create archive at {$this->_file}");
                 }
             } else {
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: The location specified is not writable: {$this->_filename}");
+                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: The location specified is not writable: {$this->_file}");
             }
         } else {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: The location specified does not exist: {$this->_filename}");
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "xPDOZip: The location specified does not exist: {$this->_file}");
         }
     }
 
@@ -147,9 +147,14 @@ class xPDOZip {
     public function unpack($target, $options = array()) {
         $results = false;
         if ($this->_archive) {
-            if (is_dir($target) && is_writable($target)) {
-                $results = $this->_archive->extractTo($target);
-            }
+            if (is_dir($target) && is_writable($target) || $this->xpdo->cacheManager->writeTree($target)) {
+                if ($this->_archive->extractTo($target)) {
+                    for ($i = 0; $i < $this->_archive->numFiles; $i++ ){ 
+                        $entry = $this->_archive->statIndex($i); 
+                        $results[] = dirname($target) . DIRECTORY_SEPARATOR . $entry['name'];
+                    }
+                }
+            } 
         }
         return $results;
     }


### PR DESCRIPTION
Small improvements of the xpdozip class:
- just cosmetic, changed $filename to $file, as this variable actually holds the whole path to the file and not just the filename
- Refactored the constructor that the class can be loaded via $modx->getService() like that:

```
$ziparchive = MODX_ASSETS_PATH . 'somezipfile.zip';
$targetdir = MODX_ASSETS_PATH . 'target/directory/';

$modx->getService('zip', 'compression.xPDOZip', XPDO_CORE_PATH, array('file' => $ziparchive));
// then it could extracted like that
$results = $modx->zip->unpack($targetdir); // the $results variable contains an array of unpacked folders an files (full paths)
$modx->zip->close();
```

the changes look a bit ugly, but as I don't want to break any current implementations, I had to do it like that...if somebody knows a better way, please tell =)
- Made the unpack() method actually return what it seems to be supposed to return as of @return array An array of results for the operation. This wasn't the case as the ZipArchive method extractTo() returns a boolean and not an array of files/paths, so I added the logic to do that
- Improved the unpack method so it writes a directory tree if the target path does not exist, before it just failed...pclzip does this on its own

PR related to https://github.com/modxcms/revolution/pull/11356 and https://github.com/modxcms/revolution/pull/11355
