### PR TITLE
Update xpdogenerator.class.php

### DIFF
--- a/xpdo/om/xpdogenerator.class.php
+++ b/xpdo/om/xpdogenerator.class.php
@@ -220,6 +220,12 @@ abstract class xPDOGenerator {
                         if ($objAttrKey == 'class') continue;
                         $this->map[$class][$objAttrKey]= (string) $objAttr;
                     }
+                    
+                    $engine = (string) $object['engine'];
+                    if (!empty($engine)) {
+                        $this->map[$class]['tableMeta'] = array('engine' => $engine);
+                    }
+                    
                     $this->map[$class]['fields']= array();
                     $this->map[$class]['fieldMeta']= array();
                     if (isset($object->field)) {


### PR DESCRIPTION
It's a little hack that fixes the issue of the engine attribute being ignored i the schema preventing tables to be created using InnoDB.
