### PR TITLE
Accept benign values that contain the word union

### DIFF
--- a/xpdo/om/xpdoquery.class.php
+++ b/xpdo/om/xpdoquery.class.php
@@ -808,7 +808,7 @@ abstract class xPDOQuery extends xPDOCriteria {
         $output = preg_replace('/\\".*?\\"/', '{mask}', $output);
         $output = preg_replace("/'.*?'/", '{mask}', $output);
         $output = preg_replace('/".*?"/', '{mask}', $output);
-        return strpos($output, ';') === false && strpos(strtolower($output), 'union') === false;
+        return strpos($output, ';') === false && strpos(strtolower($output), 'union ') === false;
     }
 
     /**


### PR DESCRIPTION
https://github.com/modxcms/revolution/issues/12121

A context key with the word "union" in it, e.g. "unionworkers", triggers many "SQL injection attempt detected" errors. As far as I know, a malicious SQL "union" keyword will always be followed by a space. Perhaps checking for "union " (with a space) instead of "union" will solve some problems without sacrificing safety.