### PR TITLE
Add functionality to allow comments to be included in class file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # ignore various IDE project files
 .idea/
+/.settings
+/.gitignore
+/.project

--- a/xpdo/om/xpdogenerator.class.php
+++ b/xpdo/om/xpdogenerator.class.php
@@ -735,20 +735,17 @@ abstract class xPDOGenerator {
  * @author 
  * @copyright Copyright (c) YYYY by 
  * @link http://xpdo.org/ Built with xPDO 
- * @license        		         
+ * @license
+ * [+phpdoc-package+]       		      		         
  */
 /**
- * File summary which will appear in documentation.
+ * Class summary which will appear in documentation.
  *
- * [+phpdoc-package+]
+[+properties+] 
+ *
+ * [+phpdoc-package+] 
  */
-class [+class+] extends [+extends+] {      		
-/**
- * Class summary goes here.
- *
-[+properties+]
- */	   
-}
+class [+class+] extends [+extends+] {}
 EOD;
         return $template;
     }

--- a/xpdo/om/xpdogenerator.class.php
+++ b/xpdo/om/xpdogenerator.class.php
@@ -729,19 +729,24 @@ abstract class xPDOGenerator {
         if ($this->classTemplate) return $this->classTemplate;
         $template= <<<EOD
 <?php
-class [+class+] extends [+extends+] {
-/*
- * This file is part of [+package+].
- */       		
 /**
- * This line should be a description of the class.
+ * 
+ * 
+ * @author 
+ * @copyright Copyright (c) YYYY by 
+ * @link http://xpdo.org/ Built with xPDO 
+ * @license        		         
+ */
+/**
+ * Provides access to geographical attached to major subdivisions of countries: state, province, etc.
+ *
+ * [+phpdoc-package+]
+ */
+class [+class+] extends [+extends+] {      		
+/**
+ * 
  *
 [+properties+]
- *       		
- * @author
- * @copyright
- * @license
- * [+phpdoc-package+]
  */	   
 }
 EOD;

--- a/xpdo/om/xpdogenerator.class.php
+++ b/xpdo/om/xpdogenerator.class.php
@@ -730,7 +730,7 @@ abstract class xPDOGenerator {
         $template= <<<EOD
 <?php
 /**
- * 
+ * File info goes here.
  * 
  * @author 
  * @copyright Copyright (c) YYYY by 
@@ -738,13 +738,13 @@ abstract class xPDOGenerator {
  * @license        		         
  */
 /**
- * Provides access to geographical attached to major subdivisions of countries: state, province, etc.
+ * File summary which will appear in documentation.
  *
  * [+phpdoc-package+]
  */
 class [+class+] extends [+extends+] {      		
 /**
- * 
+ * Class summary goes here.
  *
 [+properties+]
  */	   


### PR DESCRIPTION
Resolves #29, resolves #30, and resolves #56 by allowing automated creation of @property values when the class files are generated.
As seen in the slug property a comment can be imported directly from the schema file. Aggregate and Composite relations are also handled with cardinality="many" showing an array of ObjName in the description.

Original class files generated:

``` php
<?php
class myObject extends xPDOSimpleObject {}
```

This update creates class files with @property

``` php
<?php
class myObject extends xPDOSimpleObject {
/*
 * This file is part of geotracker.
 */             
/**
 * This line should be a description of the class.
 *
 * @property string $name
 * @property string $standardAbrv 
 * @property string $capital
 * @property string $country
 * @property string $slug used for seo url creation
 *
 * @property array $Cities An array of geoCity objects
 * @property geoCountry $Country
 *              
 * @author
 * @copyright
 * @license
 * @package geotracker
 */    
}
```
