### PR TITLE
Added table engine override functionality and test case.

### DIFF
--- a/test/xPDO/xPDO/xPDO.php
+++ b/test/xPDO/xPDO/xPDO.php
@@ -61,12 +61,9 @@ class xPDOTest extends xPDOTestCase {
 		if (!empty(xPDOTestHarness::$debug)) print "\n" . __METHOD__ . " = ";
 		try {
 			$this->xpdo->getManager();
-			$oldType = false;
-			if(isset($this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE])) {
-				$oldType = $this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE];
-			}
+			$oldType = $this->xpdo->getOption(xPDO::OPT_OVERRIDE_TABLE_TYPE);
 
-			$this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE] = 'INNODB';
+			$this->xpdo->setOption(xPDO::OPT_OVERRIDE_TABLE_TYPE, 'INNODB');
 
 			$result[] = $this->xpdo->manager->removeObjectContainer('Person');
 			$result[] = $this->xpdo->manager->createObjectContainer('Person');
@@ -83,11 +80,7 @@ class xPDOTest extends xPDOTestCase {
 			$result[] = $this->xpdo->manager->removeObjectContainer('Item');
 			$result[] = $this->xpdo->manager->createObjectContainer('Item');
 
-			if($oldType) {
-				$this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE] = $oldType;
-			} else {
-				unset($this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE]);
-			}
+			$this->xpdo->setOption(xPDO::OPT_OVERRIDE_TABLE_TYPE, $oldType);
 		} catch (Exception $e) {
 			$this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
 		}

--- a/test/xPDO/xPDO/xPDO.php
+++ b/test/xPDO/xPDO/xPDO.php
@@ -54,6 +54,47 @@ class xPDOTest extends xPDOTestCase {
         $this->assertTrue($result, 'Error creating tables.');
     }
 
+	/**
+	 * Test table engine override.
+	 */
+	public function testOverrideTableType() {
+		if (!empty(xPDOTestHarness::$debug)) print "\n" . __METHOD__ . " = ";
+		try {
+			$this->xpdo->getManager();
+			$oldType = false;
+			if(isset($this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE])) {
+				$oldType = $this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE];
+			}
+
+			$this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE] = 'INNODB';
+
+			$result[] = $this->xpdo->manager->removeObjectContainer('Person');
+			$result[] = $this->xpdo->manager->createObjectContainer('Person');
+
+			$result[] = $this->xpdo->manager->removeObjectContainer('Phone');
+			$result[] = $this->xpdo->manager->createObjectContainer('Phone');
+
+			$result[] = $this->xpdo->manager->removeObjectContainer('PersonPhone');
+			$result[] = $this->xpdo->manager->createObjectContainer('PersonPhone');
+
+			$result[] = $this->xpdo->manager->removeObjectContainer('BloodType');
+			$result[] = $this->xpdo->manager->createObjectContainer('BloodType');
+
+			$result[] = $this->xpdo->manager->removeObjectContainer('Item');
+			$result[] = $this->xpdo->manager->createObjectContainer('Item');
+
+			if($oldType) {
+				$this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE] = $oldType;
+			} else {
+				unset($this->xpdo->config["driverOptions"][xPDO::OPT_OVERRIDE_TABLE_TYPE]);
+			}
+		} catch (Exception $e) {
+			$this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
+		}
+		$result = !array_search(false, $result, true);
+		$this->assertTrue($result, 'Error creating tables with table type override.');
+	}
+
     /**
      * Tests xPDO::escape
      */

--- a/xpdo/om/mysql/xpdomanager.class.php
+++ b/xpdo/om/mysql/xpdomanager.class.php
@@ -135,10 +135,7 @@ class xPDOManager_mysql extends xPDOManager {
                 $modelVersion= $this->xpdo->getModelVersion($className);
                 $tableMeta= $this->xpdo->getTableMeta($className);
                 $tableType= isset($tableMeta['engine']) ? $tableMeta['engine'] : 'MyISAM';
-                $driverOptions = $this->xpdo->config["driverOptions"];
-                if(isset($driverOptions[xPDO::OPT_OVERRIDE_TABLE_TYPE])) {
-                    $tableType = $driverOptions[xPDO::OPT_OVERRIDE_TABLE_TYPE];
-                }
+                $tableType= $this->xpdo->getOption(xPDO::OPT_OVERRIDE_TABLE_TYPE, null, $tableType);
                 $legacyIndexes= version_compare($modelVersion, '1.1', '<');
                 $fulltextIndexes= array ();
                 $uniqueIndexes= array ();

--- a/xpdo/om/mysql/xpdomanager.class.php
+++ b/xpdo/om/mysql/xpdomanager.class.php
@@ -135,6 +135,10 @@ class xPDOManager_mysql extends xPDOManager {
                 $modelVersion= $this->xpdo->getModelVersion($className);
                 $tableMeta= $this->xpdo->getTableMeta($className);
                 $tableType= isset($tableMeta['engine']) ? $tableMeta['engine'] : 'MyISAM';
+                $driverOptions = $this->xpdo->config["driverOptions"];
+                if(isset($driverOptions[xPDO::OPT_OVERRIDE_TABLE_TYPE])) {
+                    $tableType = $driverOptions[xPDO::OPT_OVERRIDE_TABLE_TYPE];
+                }
                 $legacyIndexes= version_compare($modelVersion, '1.1', '<');
                 $fulltextIndexes= array ();
                 $uniqueIndexes= array ();

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -116,6 +116,7 @@ class xPDO {
     const OPT_CONNECTIONS = 'connections';
     const OPT_CONN_INIT = 'connection_init';
     const OPT_CONN_MUTABLE = 'connection_mutable';
+    const OPT_OVERRIDE_TABLE_TYPE = 'override_table';
     const OPT_HYDRATE_FIELDS = 'hydrate_fields';
     const OPT_HYDRATE_ADHOC_FIELDS = 'hydrate_adhoc_fields';
     const OPT_HYDRATE_RELATED_OBJECTS = 'hydrate_related_objects';


### PR DESCRIPTION
I currently host all MODX sites on a Percona Galera Cluster. There is a constraint with this that ALL tables have to be INNODB rather than MyISAM, xpdo currently defaults to MyISAM but allows the schema to use a different table engine.

With this pull request I can enforce a specific table type this allows me to create INNODB tables when the table schema and defaults are MYISAM.

Without this implementation I need to create the tables in a non-clustered environment and ALTER them to INNODB before creation.

This can be enforced by using the driverOption

```
$properties['mysql_array_driverOptions']= array(
	xPDO::OPT_OVERRIDE_TABLE_TYPE => 'INNODB'
);
```

In theory this can be used to use any table type (E.G. memory or blackhole) but in some situations table creation could fail.

It's worth noting that MySQL 5.6 is required for INNODB to support FULLTEXT indexes.