### PR TITLE
fix for "gzopen not found" issue on some installations

### DIFF
--- a/src/xPDO/Compression/pclzip.lib.php
+++ b/src/xPDO/Compression/pclzip.lib.php
@@ -216,9 +216,13 @@
   {
 
     // ----- Tests the zlib
-    if (!function_exists('gzopen'))
+   if (!extension_loaded('zlib'))
     {
       die('Abort '.basename(__FILE__).' : Missing zlib extensions');
+    }
+    if (!function_exists('gzopen') && !function_exists('gzopen64'))
+    {
+      die('Abort '.basename(__FILE__).' : Could not find gzopen');
     }
 
     // ----- Set the attributes


### PR DESCRIPTION
this fix is for systems were php gzopen function is renamed to gzopen64 (mostly on Ubuntu 14.04+ x32)
details on this issue could be found in the following launchpad thread: https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1315888
