### PR TITLE
xpdo::getOption performance improvement

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -686,16 +686,15 @@ class xPDO {
         $option= $default;
         if (is_array($key)) {
             if (!is_array($option)) {
-                $default= $option;
                 $option= array();
             }
             foreach ($key as $k) {
                 $option[$k]= $this->getOption($k, $options, $default);
             }
         } elseif (is_string($key) && !empty($key)) {
-            if (is_array($options) && !empty($options) && array_key_exists($key, $options) && (!$skipEmpty || ($skipEmpty && $options[$key] !== ''))) {
+            if (is_array($options) && (isset($options[$key]) || array_key_exists($key, $options)) && (!$skipEmpty || ($skipEmpty && $options[$key] !== ''))) {
                 $option= $options[$key];
-            } elseif (is_array($this->config) && !empty($this->config) && array_key_exists($key, $this->config) && (!$skipEmpty || ($skipEmpty && $this->config[$key] !== ''))) {
+            } elseif (is_array($this->config) && (isset($this->config[$key]) || array_key_exists($key, $this->config)) && (!$skipEmpty || ($skipEmpty && $this->config[$key] !== ''))) {
                 $option= $this->config[$key];
             }
         }

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -683,21 +683,27 @@ class xPDO {
      * @return mixed The configuration option value.
      */
     public function getOption($key, $options = null, $default = null, $skipEmpty = false) {
-        $option= $default;
-        if (is_array($key)) {
+        $option = null;
+        if (is_string($key) && !empty($key)) {
+            if (isset($options[$key]))
+                $option = $options[$key];
+
+            if (empty($option) && ($option !== '' || $skipEmpty) && isset($this->config[$key]))
+                $option = $this->config[$key];
+
+            if (empty($option) && ($option !== '' || $skipEmpty))
+                $option = $default;
+        }
+        else if (is_array($key)) {
             if (!is_array($option)) {
-                $option= array();
+                $default = $option;
+                $option = array();
             }
-            foreach ($key as $k) {
-                $option[$k]= $this->getOption($k, $options, $default);
-            }
-        } elseif (is_string($key) && !empty($key)) {
-            if (is_array($options) && (isset($options[$key]) || array_key_exists($key, $options)) && (!$skipEmpty || ($skipEmpty && $options[$key] !== ''))) {
-                $option= $options[$key];
-            } elseif (is_array($this->config) && (isset($this->config[$key]) || array_key_exists($key, $this->config)) && (!$skipEmpty || ($skipEmpty && $this->config[$key] !== ''))) {
-                $option= $this->config[$key];
+            foreach($key as $k) {
+                $option[$k] = $this->getOption($k, $options, $default);
             }
         }
+
         return $option;
     }
 

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -685,13 +685,18 @@ class xPDO {
     public function getOption($key, $options = null, $default = null, $skipEmpty = false) {
         $option = null;
         if (is_string($key) && !empty($key)) {
-            if (isset($options[$key]))
+            $found = false;
+            if (isset($options[$key])) {
+                $found = true;
                 $option = $options[$key];
+            }
 
-            if (empty($option) && ($option !== '' || $skipEmpty) && isset($this->config[$key]))
+            if ((!$found || (empty($option) && ($option === '' || $skipEmpty))) && isset($this->config[$key])) {
+                $found = true;
                 $option = $this->config[$key];
+            }
 
-            if (empty($option) && ($option !== '' || $skipEmpty))
+            if (!$found || (empty($option) && ($option === '' || $skipEmpty)))
                 $option = $default;
         }
         else if (is_array($key)) {
@@ -702,8 +707,9 @@ class xPDO {
             foreach($key as $k) {
                 $option[$k] = $this->getOption($k, $options, $default);
             }
-        } else
-			$option = $default;
+        }
+        else
+            $option = $default;
 
         return $option;
     }

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -702,7 +702,8 @@ class xPDO {
             foreach($key as $k) {
                 $option[$k] = $this->getOption($k, $options, $default);
             }
-        }
+        } else
+			$option = $default;
 
         return $option;
     }


### PR DESCRIPTION
Only call more expensive function 'array_key_exists' when 'isset' fails, leads to ca 15-20% performance increases for server response time in our specific modx site.

(skipping 'array_key_exists' leads to an extra 5-10% performance increase but would change the result if the value is null)
