### PR TITLE
xpdo::getOption fix skipEmpty logic (v2)

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -691,12 +691,12 @@ class xPDO {
                 $option = $options[$key];
             }
 
-            if ((!$found || ($option === '' && $skipEmpty)) && isset($this->config[$key])) {
+            if ((!$found || ($skipEmpty && $option === '')) && isset($this->config[$key])) {
                 $found = true;
                 $option = $this->config[$key];
             }
 
-            if (!$found || ($option === '' && $skipEmpty))
+            if (!$found || ($skipEmpty && $option === ''))
                 $option = $default;
         }
         else if (is_array($key)) {

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -691,12 +691,12 @@ class xPDO {
                 $option = $options[$key];
             }
 
-            if ((!$found || (empty($option) && ($option === '' || $skipEmpty))) && isset($this->config[$key])) {
+            if ((!$found || ($option === '' && $skipEmpty)) && isset($this->config[$key])) {
                 $found = true;
                 $option = $this->config[$key];
             }
 
-            if (!$found || (empty($option) && ($option === '' || $skipEmpty)))
+            if (!$found || ($option === '' && $skipEmpty))
                 $option = $default;
         }
         else if (is_array($key)) {


### PR DESCRIPTION
Fix problems with the skipEmtpy option (second try) and remove an unnecessary 'empty' check
