### PR TITLE
File resolve options

### DIFF
--- a/xpdo/transport/xpdofilevehicle.class.php
+++ b/xpdo/transport/xpdofilevehicle.class.php
@@ -212,11 +212,12 @@ class xPDOFileVehicle extends xPDOVehicle {
                 }
                 if (file_exists($fileSource) && is_writable($fileTarget)) {
                     $copied = false;
+					$options = isset($object[xPDOTransport::FILE_RESOLVE_OPTIONS]) ? $object[xPDOTransport::FILE_RESOLVE_OPTIONS] : array();
                     if (is_dir($fileSource)) {
-                        $copied = $cacheManager->copyTree($fileSource, $fileTarget . $fileName);
+                        $copied = $cacheManager->copyTree($fileSource, $fileTarget . $fileName, $options);
                     }
                     elseif (is_file($fileSource)) {
-                        $copied = $cacheManager->copyFile($fileSource, $fileTarget . $fileName);
+                        $copied = $cacheManager->copyFile($fileSource, $fileTarget . $fileName, $options);
                     }
                     if (!$copied) {
                         $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not copy file from {$fileSource} to {$fileTarget}{$fileName}");

--- a/xpdo/transport/xpdotransport.class.php
+++ b/xpdo/transport/xpdotransport.class.php
@@ -58,6 +58,7 @@ class xPDOTransport {
     const ABORT_INSTALL_ON_VEHICLE_FAIL = 'abort_install_on_vehicle_fail';
     const PACKAGE_NAME = 'package_name';
     const PACKAGE_VERSION = 'package_version';
+    const FILE_RESOLVE_OPTIONS = 'file_resolve_options';
     /**
      * Indicates how pre-existing objects are treated on install/uninstall.
      * @var integer

--- a/xpdo/transport/xpdovehicle.class.php
+++ b/xpdo/transport/xpdovehicle.class.php
@@ -383,6 +383,7 @@ abstract class xPDOVehicle {
         $cacheManager = $transport->xpdo->getCacheManager();
         if ($cacheManager) {
             if (isset ($this->payload['resolve']) && is_array($this->payload['resolve'])) {
+				$fro = isset($this->payload[xPDOTransport::FILE_RESOLVE_OPTIONS]) ? $this->payload[xPDOTransport::FILE_RESOLVE_OPTIONS] : array();
                 foreach ($this->payload['resolve'] as $rKey => $r) {
                     $type = $r['type'];
                     $body = array ();
@@ -399,11 +400,15 @@ abstract class xPDOVehicle {
                             }
                             if (file_exists($fileSource) && is_writable($fileTarget)) {
                                 $copied = false;
+								$o = $fro;
+								if (isset($r[xPDOTransport::FILE_RESOLVE_OPTIONS])) {
+									$o = array_merge($fro, $r[xPDOTransport::FILE_RESOLVE_OPTIONS]);
+								}
                                 if (is_dir($fileSource)) {
-                                    $copied = $cacheManager->copyTree($fileSource, $fileTarget . $fileName);
+                                    $copied = $cacheManager->copyTree($fileSource, $fileTarget . $fileName, $o);
                                 }
                                 elseif (is_file($fileSource)) {
-                                    $copied = $cacheManager->copyFile($fileSource, $fileTarget . $fileName);
+                                    $copied = $cacheManager->copyFile($fileSource, $fileTarget . $fileName, $o);
                                 }
                                 if (!$copied) {
                                     $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not copy file from {$fileSource} to {$fileTarget}{$fileName}");


### PR DESCRIPTION
Lets user set cacheManager copy options, e.g. 'copy_exclude_patterns' to exclude specific subdirectories from the transport package

Usage: add **xPDOTransport::FILE_RESOLVE_OPTIONS => array()** to the **$builder->createVehicle** (vehicle global) or **$vehicle->resolve** (single object) attributes
