### PR TITLE
writeFile, do not force append mode

### DIFF
--- a/xpdo/cache/xpdocachemanager.class.php
+++ b/xpdo/cache/xpdocachemanager.class.php
@@ -219,7 +219,7 @@ class xPDOCacheManager {
                 $append = false;
                 break;
         }
-        $fmode = (strlen($mode) > 1 && in_array($mode[1], array('b', 't'))) ? "a{$mode[1]}" : 'a';
+        $fmode = (strlen($mode) > 1 && in_array($mode[1], array('b', 't'))) ? "{$mode[0]}{$mode[1]}" : $mode[0];
         $file= @fopen($filename, $fmode);
         if ($file) {
             if ($append === true) {


### PR DESCRIPTION
use the actual $mode parameter instead of forcing append mode.

This behaviour caused problems on our load balancing server configuration (2 servers accessing the same modx cache directory using NFS). It lead to corrupt cache; despite the pointer is being set to the start of the file, the cache file would contain appended content.
