### PR TITLE
Add option to respect PSR-4 namespaces

### DIFF
--- a/bin/xpdo.php
+++ b/bin/xpdo.php
@@ -91,10 +91,11 @@ switch ($command) {
             exit(128);
         }
         $path = $arg(3);
-
+        
         $compile = $opt('compile') || $opt('c');
         $update = $opt('update');
         $regen = $opt('regen');
+        $withNamespace = (intval($opt('psr4')) == 1) ? 0 : 1;
 
         $update = $update === false ? 0 : (int)$update;
         $regen = $regen === false ? 0 : (int)$regen;
@@ -111,6 +112,7 @@ switch ($command) {
                 'compile' => $compile,
                 'update' => $update,
                 'regenerate' => $regen,
+                'withNamespace' => $withNamespace,
             )
         );
         exit(0);
@@ -128,7 +130,7 @@ switch ($command) {
 
 echo <<<'EOF'
 Example usage:
-  xpdo parse-schema [[--config|-C]=CONFIG/FILE] [[--compile|-c]|--update=[0-2]|--regen=[0-2]] PLATFORM SCHEMA_FILE PATH
+  xpdo parse-schema [[--config|-C]=CONFIG/FILE] [[--compile|-c]|--update=[0-2]|--regen=[0-2]] [--psr4] PLATFORM SCHEMA_FILE PATH
   xpdo write-schema [[--config|-C]=CONFIG/FILE] [?] PLATFORM SCHEMA_FILE PATH
 
 EOF;


### PR DESCRIPTION
With this change when using PSR-4 autoloader for example:

``` json
"autoload": {
    "psr-4": {
        "MyApp\\": ["src/"]
    }
}
```

It wasn't possible to generate classes to `src/Model` with namespace `MyApp\Model` - it was creating all classes under `src/MyApp/Model`.

Now you can pass `--psr4` option to `xpdo parse-schema`, specify target dir as `src/Model` and schema namespace as `MyApp\Model`.

Also it fixes generating classes like `Person\Phone` now generates:
- src/Model/Person/Phone.php
- src/Model/Person/platform/Phone.php

Resolves #80 
