### PR TITLE
Fix defining single/multiple primary key by "index" node

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -1540,9 +1540,11 @@ class xPDO {
             if ($actualClassName= $this->loadClass($className)) {
                 if (isset ($this->map[$actualClassName]['indexes'])) {
                     foreach ($this->map[$actualClassName]['indexes'] as $k => $v) {
-                        if (isset ($this->map[$actualClassName]['fieldMeta'][$k]['phptype'])) {
-                            if (isset ($v['primary']) && $v['primary'] == true) {
-                                $pk[$k]= $k;
+                        if (isset($v['primary']) && ($v['primary'] == true) && isset($v['columns'])) {
+                            foreach ($v['columns'] as $field => $column) {
+                                if (isset ($this->map[$actualClassName]['fieldMeta'][$field]['phptype'])) {
+                                    $pk[$field] = $field;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes defining primary key by (single or multiple columns):

``` xml
<index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
    <column key="column1" length="" collation="A" null="false" />
    <column key="column2" length="" collation="A" null="false" />
</index>
```

This notation wasn't accepted in `\xPDO\xPDO->getPK()` method, and primary key had to be define by `index="pk"` attribute in each PK column.

This may be applied also for 2.x branch.

Resolves #81
