### PR TITLE
Generates phpdoc @property for each column to allow autocompletion

### DIFF
--- a/src/xPDO/Om/xPDOGenerator.php
+++ b/src/xPDO/Om/xPDOGenerator.php
@@ -827,33 +827,37 @@ EOD;
             ' *'
         );
         
-        foreach ($meta['fieldMeta'] as $field => $def) {
-            $type = $def['phptype'];
-            switch ($type) {
-                case 'timestamp':
-                case 'datetime':
-                case 'date':
-                    $type = 'string';
-                    break;
-                case 'json':
-                    $type = 'array';
-                    break;
-            }
-            
-            $properties[] = ' * @property ' . $type . ' $' . $field;
-        }
-        
-        if (isset($meta['composites'])) {
-            $properties[] = ' *';
-            foreach ($meta['composites'] as $field => $def) {
-                $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
+        if ($this->manager->xpdo->getOption(xPDO::OPT_HYDRATE_FIELDS)) {
+            foreach ($meta['fieldMeta'] as $field => $def) {
+                $type = $def['phptype'];
+                switch ($type) {
+                    case 'timestamp':
+                    case 'datetime':
+                    case 'date':
+                        $type = 'string';
+                        break;
+                    case 'json':
+                        $type = 'array';
+                        break;
+                }
+                
+                $properties[] = ' * @property ' . $type . ' $' . $field;
             }
         }
+
+        if ($this->manager->xpdo->getOption(xPDO::OPT_HYDRATE_RELATED_OBJECTS)) {
+            if (isset($meta['composites'])) {
+                $properties[] = ' *';
+                foreach ($meta['composites'] as $field => $def) {
+                    $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
+                }
+            }
         
-        if (isset($meta['aggregations'])) {
-            $properties[] = ' *';
-            foreach ($meta['aggregations'] as $field => $def) {
-                $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
+            if (isset($meta['aggregations'])) {
+                $properties[] = ' *';
+                foreach ($meta['aggregations'] as $field => $def) {
+                    $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
+                }
             }
         }
         

--- a/src/xPDO/Om/xPDOGenerator.php
+++ b/src/xPDO/Om/xPDOGenerator.php
@@ -517,7 +517,6 @@ abstract class xPDOGenerator {
             if (count($classExploded) > 0) {
                 $namespace .= implode('\\', $classExploded);
             }
-            $classDef['phpdoc-properties'] = $this->constructPhpDocProperties($this->map[$className]);
             $classDef['namespace']= $namespace;
             $classDef['class-fullname']= $classFullName = "{$namespace}\\{$className}";
             $classDef['class-platform']= $platformClass = "{$namespace}\\{$this->model['platform']}\\{$classShortName}";
@@ -799,6 +798,7 @@ EOD;
         $meta['class-close-declaration'] = "}\n";
         $meta['class-footer'] = $this->_constructClassFooter($class, $meta);
         $meta['phpdoc-start'] = $this->_constructPhpDocStart($class, $meta);
+        $meta['phpdoc-properties'] = $this->_constructPhpDocProperties($this->map[$meta['class']]);
         $meta['phpdoc-end'] = $this->_constructPhpDpcEnd($class, $meta);
     }
     
@@ -822,7 +822,7 @@ EOD;
         return implode(PHP_EOL, $output);
     }
     
-    protected function constructPhpDocProperties($meta) {
+    protected function _constructPhpDocProperties($meta) {
         $properties = array(
             ' *'
         );

--- a/src/xPDO/Om/xPDOGenerator.php
+++ b/src/xPDO/Om/xPDOGenerator.php
@@ -517,6 +517,7 @@ abstract class xPDOGenerator {
             if (count($classExploded) > 0) {
                 $namespace .= implode('\\', $classExploded);
             }
+            $classDef['phpdoc-properties'] = $this->constructPhpDocProperties($this->map[$className]);
             $classDef['namespace']= $namespace;
             $classDef['class-fullname']= $classFullName = "{$namespace}\\{$className}";
             $classDef['class-platform']= $platformClass = "{$namespace}\\{$this->model['platform']}\\{$classShortName}";
@@ -647,6 +648,9 @@ abstract class xPDOGenerator {
         if ($this->classTemplate) return $this->classTemplate;
         $template= <<<'EOD'
 [+class-header+]
+[+phpdoc-start+]
+[+phpdoc-properties+]
+[+phpdoc-end+]
 [+class-declaration+]
 [+class-traits+][+class-constants+][+class-properties+][+class-methods+][+class-close-declaration+][+class-footer+]
 EOD;
@@ -794,6 +798,66 @@ EOD;
         $meta['class-methods'] = implode("\n", $this->_constructClassMethods($class, $meta));
         $meta['class-close-declaration'] = "}\n";
         $meta['class-footer'] = $this->_constructClassFooter($class, $meta);
+        $meta['phpdoc-start'] = $this->_constructPhpDocStart($class, $meta);
+        $meta['phpdoc-end'] = $this->_constructPhpDpcEnd($class, $meta);
+    }
+    
+    protected function _constructPhpDocStart($class, $meta) {
+        $output = array(
+            '/**'
+        );
+        $output[] = ' * Class ' . $meta['class-shortname'];
+        
+        return implode(PHP_EOL, $output);
+    }
+    
+    protected function _constructPhpDpcEnd($class, $meta) {
+        $output = array(
+            ' *'
+        );
+        
+        $output[] = ' * @package ' . $meta['namespace'];
+        $output[] = ' */';
+
+        return implode(PHP_EOL, $output);
+    }
+    
+    protected function constructPhpDocProperties($meta) {
+        $properties = array(
+            ' *'
+        );
+        
+        foreach ($meta['fieldMeta'] as $field => $def) {
+            $type = $def['phptype'];
+            switch ($type) {
+                case 'timestamp':
+                case 'datetime':
+                case 'date':
+                    $type = 'string';
+                    break;
+                case 'json':
+                    $type = 'array';
+                    break;
+            }
+            
+            $properties[] = ' * @property ' . $type . ' $' . $field;
+        }
+        
+        if (isset($meta['composites'])) {
+            $properties[] = ' *';
+            foreach ($meta['composites'] as $field => $def) {
+                $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
+            }
+        }
+        
+        if (isset($meta['aggregations'])) {
+            $properties[] = ' *';
+            foreach ($meta['aggregations'] as $field => $def) {
+                $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
+            }
+        }
+        
+        return implode(PHP_EOL, $properties);
     }
 
     protected function _constructClass($fileName, $meta, $template) {


### PR DESCRIPTION
With this change it's not necessary to update all class files manually and add all `@property` comments to allow autocompletion.

This change generates `@property` comment for each column and relation.
Example:
<img width="559" alt="screen shot 2016-01-27 at 11 40 22" src="https://cloud.githubusercontent.com/assets/845220/12610964/c9586b04-c4ea-11e5-861b-fbb4060a3aa4.png">
