### PR TITLE
Added usage of debug_backtrace in _log()

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -2029,6 +2029,17 @@ class xPDO {
             if (isset($target['options'])) $targetOptions =& $target['options'];
             $target = isset($target['target']) ? $target['target'] : 'ECHO';
         }
+        if (empty($file) && function_exists('debug_backtrace')) {
+            if (version_compare(phpversion(), '5.3.6', '>=')) {
+                $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+            } else {
+                $backtrace = debug_backtrace();
+            }
+            if ($backtrace && isset($backtrace[2])) {
+                $file = $backtrace[2]['file'];
+                $line = $backtrace[2]['line'];
+            }
+        }
         if (empty($file) && isset($_SERVER['SCRIPT_NAME'])) {
             $file= $_SERVER['SCRIPT_NAME'];
         }


### PR DESCRIPTION
### What does it do ?

Implemented `debug_backtrace()` in the `_log()` function for _much_ better error message that show the actual affected file and line number instead of just `$_SERVER['SCRIPT_NAME']` which results in a lot of error messages with `index.php` as file.

For PHP 5.3.6+ `debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)` is used which uses less memory.
### Why is it needed ?

More helpful error message with the actual affected file.
### Related issue(s)/PR(s)
## 
