### PR TITLE
Make sure FileCache uses correct permissions and optionally allow different permissions

### DIFF
--- a/xpdo/cache/xpdocachemanager.class.php
+++ b/xpdo/cache/xpdocachemanager.class.php
@@ -253,6 +253,10 @@ class xPDOCacheManager {
                 }
             }
             @fclose($file);
+            if ($written !== false && $fileMode = $this->getOption('new_file_permissions', $options, false)) {
+                if (is_string($fileMode)) $fileMode = octdec($fileMode);
+                @ chmod($filename, $fileMode);
+            }
         }
         return ($written !== false);
     }
@@ -335,7 +339,7 @@ class xPDOCacheManager {
             } else {
                 $written= @ mkdir($dirname, $mode);
             }
-            if ($written && !is_writable($dirname)) {
+            if ($written) {
                 @ chmod($dirname, $mode);
             }
         }
@@ -987,7 +991,11 @@ class xPDOFileCache extends xPDOCache {
                     $content= '<?php ' . $expireContent . ' return ' . var_export($var, true) . ';';
                     break;
             }
-            $set= $this->xpdo->cacheManager->writeFile($fileName, $content);
+            $folderMode = $this->getOption('new_cache_folder_permissions', $options, false);
+            if ($folderMode) $options['new_folder_permissions'] = $folderMode;
+            $fileMode = $this->getOption('new_cache_file_permissions', $options, false);
+            if ($fileMode) $options['new_file_permissions'] = $fileMode;
+            $set= $this->xpdo->cacheManager->writeFile($fileName, $content, 'wb', $options);
         }
         return $set;
     }


### PR DESCRIPTION
### What does it do?

1) Update xPDOCacheManager to use and force the folder/file permissions set in the `new_folder_permissions` and `new_file_permissions` settings (if those are set).

2) Introduce 2 new optional settings `new_folder_permissions_cache` and `new_file_permissions_cache` that can be set to use different folder and file permissions for the cache when using `xPDOFileCache`.
### Why is it needed?

The file cache wasn't respecting the settings if you e.g. need `0775` permissions on folders/files. I had this now in 2 projects that I needed different file permissions for the cache files, due to restrictions and/or security concerns from the infrastructure. (E.g. multiple servers sharing the file system, each with different default permissions)
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/pull/12677
