### PR TITLE
Possible fix for blind SQL injection

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -1132,7 +1132,30 @@ class xPDO {
      * @return xPDOCriteria A criteria object or null if not found.
      */
     public function getCriteria($className, $type= null, $cacheFlag= true) {
-        return $this->newQuery($className, $type, $cacheFlag);
+        $c = $this->newQuery($className);
+        $c->cacheFlag = $cacheFlag;
+        if (!empty($type)) {
+            if ($type instanceof xPDOCriteria) {
+                $c->wrap($type);
+            } elseif (is_array($type)) {
+                $tmp = array();
+                array_walk_recursive($type, function ($v, $k) use (&$tmp) {
+                    if (!is_numeric($k)) {
+                        $tmp[$k] = $v;
+                    }
+                });
+                if (count($tmp)) {
+                    $c->where($tmp);
+                }
+            } elseif (is_scalar($type)) {
+                if ($pk = $this->getPK($className)) {
+                    $c->where(array($pk => $type));
+                }
+            } else {
+                $c->where($type);
+            }
+        }
+        return $c;
     }
 
     /**


### PR DESCRIPTION
For now, if there is a string when you get an object, this string will be passed as an criteria for SQL query. So, if you want just to get an object with primary key, but not filter a user request enough, there could be a blind SQL injection.

This fix will force all conditions to be an:
1. primary key
2. or array with non-numeric keys and values
3. or xPDOQuery

No RAW SQL queries could be made with `getObject` call.