### PR TITLE
[Vuln 34] SQL injections in ORDER BY and LIMIT clauses

### DIFF
--- a/xpdo/om/xpdoquery.class.php
+++ b/xpdo/om/xpdoquery.class.php
@@ -404,53 +404,10 @@ abstract class xPDOQuery extends xPDOCriteria {
             $direction = 'ASC';
         }
 
-        $column = $this->cleanSortColumn($column);
         if (!empty($column)) {
             $this->query['sortby'][] = array('column' => $column, 'direction' => $direction);
         }
         return $this;
-    }
-
-    /**
-     * To prevent SQL injections, what's passed into the sortby() method gets escaped automatically.
-     *
-     * If you have a *very good reason* to need the raw value to be inserted, you can do so by calling sortbyRaw(true)
-     * before calling sortby with your value. This will, for a single sortby() call, allow any SQL to be inserted
-     * into the ORDER BY clause.
-     *
-     * This method does NOT need to be called for a `rand()` order; that's already whitelisted.
-     *
-     * @param bool $val
-     */
-    public function sortbyRaw($val = false)
-    {
-        $this->_rawSortby = (bool)$val;
-    }
-
-    /**
-     * Called from sortby(), this method ensures that the column value is allowed. This automatically escapes the
-     * column (unless it is RAND() or sortbyRaw(true) was called).
-     *
-     * @param string $column
-     * @return string
-     */
-    public function cleanSortColumn($column)
-    {
-        // If sortbyRaw(true) was called, allow the sort column to be injected as-is. This is used for
-        // complex ordering such as FIELD(table.field, val1, val2, val3), however also exposes SQL injections
-        // if the provided SQL comes from a potentially untrusted source.
-        if ($this->_rawSortby) {
-            $this->_rawSortby = false;
-            return $column;
-        }
-
-        // If the column dictates a random ordering, allow that as well
-        if (strtoupper($column) === 'RAND()') {
-            return $column;
-        }
-
-        // Anything else needs to be escaped
-        return $this->xpdo->escape($column);
     }
 
     /**

--- a/xpdo/om/xpdoquery.class.php
+++ b/xpdo/om/xpdoquery.class.php
@@ -672,8 +672,11 @@ abstract class xPDOQuery extends xPDOCriteria {
      */
     public function prepare($bindings= array (), $byValue= true, $cacheFlag= null) {
         $this->stmt= null;
-        if ($this->construct() && $this->stmt= $this->xpdo->prepare($this->sql)) {
+        if ($this->construct() && $this->isValidClause($this->sql) && $this->stmt= $this->xpdo->prepare($this->sql)) {
             $this->bind($bindings, $byValue, $cacheFlag);
+        }
+        else {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not construct or prepare query because it is invalid or could not connect: ' . $this->sql);
         }
         return $this->stmt;
     }


### PR DESCRIPTION
Following a report from Nikolay Lanets on November 4th, several SQL injections in xPDO have been found and fixed.

When creating a SQL query through an xPDOQuery object (as virtually any core and third party code interacting with the database does), the `sortby` and `limit` methods accepted arbitrary SQL which was not properly sanitised.

While this vulnerability existed within the xPDOQuery object, the original report from Nikolay and further testing shows that it could be exploited without writing and executing arbitrary code. This includes by providing specially crafted arguements to connectors/processors (requiring a valid manager session), or by a snippet call that passes a sort or limit to xPDOQuery directly.

As these are common scenarios that can't reasonably be resolved in each specific calling function, this has been patched at the xPDOQuery level at the cost of a breaking change to extras (and possibly MODX core code) that do rely on the sort accepting abitrary SQL, for example the common approach for sorting resources in a specific order with sort clauses like `FIELD(modResource.id, 1, 2, 3)`. These order clauses will no longer work following this patch, unless the snippet indicates the input should be trusted by calling the `sortbyRaw` method with a value of `true`.