### PR TITLE
Fix isValidClause check for certain injections

### DIFF
--- a/xpdo/om/xpdoquery.class.php
+++ b/xpdo/om/xpdoquery.class.php
@@ -808,7 +808,7 @@ abstract class xPDOQuery extends xPDOCriteria {
         $output = preg_replace('/\\".*?\\"/', '{mask}', $output);
         $output = preg_replace("/'.*?'/", '{mask}', $output);
         $output = preg_replace('/".*?"/', '{mask}', $output);
-        return strpos($output, ';') === false && strpos(strtolower($output), 'union ') === false;
+        return strpos($output, ';') === false && strpos(strtolower($output), 'union') === false;
     }
 
     /**


### PR DESCRIPTION
Notified about issue by ~Vasily Naumkin~ Eugeny Borisov. Specific injections using UNION could be used to bypass the check.