### PR TITLE
Force all scalar expressions to be a primary key

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -1132,7 +1132,21 @@ class xPDO {
      * @return xPDOCriteria A criteria object or null if not found.
      */
     public function getCriteria($className, $type= null, $cacheFlag= true) {
-        return $this->newQuery($className, $type, $cacheFlag);
+        $c = $this->newQuery($className);
+        $c->cacheFlag = $cacheFlag;
+        if (!empty($type)) {
+            if ($type instanceof xPDOCriteria) {
+                $c->wrap($type);
+            } elseif (is_scalar($type)) {
+                if ($pk = $this->getPK($className)) {
+                    $c->where(array($pk => $type));
+                }
+            } else {
+                $c->where($type);
+            }
+        }
+
+        return $c;
     }
 
     /**


### PR DESCRIPTION
This is my second attempt to fix possible blind SQL injection in getObject method.

Now it passes tests and must not break any functionality.