### PR TITLE
Make isValidClause public

### DIFF
--- a/xpdo/om/xpdoquery.class.php
+++ b/xpdo/om/xpdoquery.class.php
@@ -813,7 +813,7 @@ abstract class xPDOQuery extends xPDOCriteria {
         return $matched;
     }
 
-    protected function isValidClause($clause) {
+    public function isValidClause($clause) {
         $output = rtrim($clause, ' ;');
         $output = preg_replace("/\\\\'.*?\\\\'/", '{mask}', $output);
         $output = preg_replace('/\\".*?\\"/', '{mask}', $output);


### PR DESCRIPTION
I think we should make this method public, because property "query" is public already and we can add anything to it manually.

And it will be better to check clause by built-in xPDO method before this.