### PR TITLE
Fixing a PHP 7 issue

### DIFF
--- a/xpdo/compression/pclzip.lib.php
+++ b/xpdo/compression/pclzip.lib.php
@@ -212,7 +212,7 @@
   //   Note that no real action is taken, if the archive does not exist it is not
   //   created. Use create() for that.
   // --------------------------------------------------------------------------------
-  function PclZip($p_zipname)
+  function __construct($p_zipname)
   {
 
     // ----- Tests the zlib


### PR DESCRIPTION
Changing the constructor would be no problem (or does xPDO has to be PHP4 compatible)

See https://github.com/modxcms/revolution/issues/13188