### PR TITLE
Add travis configuration to automatically run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: php
 script: "phpunit -c ./test/complete.phpunit.xml"
+env:
+  matrix:
+    - TEST_DRIVER=mysql
+    - TEST_DRIVER=sqlite
+
 services: mysql
 
 # Set php versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - php: hhvm
 
 before_script:
-  - composer install
+  - composer install --no-dev --prefer-dist --no-interaction
   - cp test/properties.travis.inc.php test/properties.inc.php
   - mysql -e 'create database xpdotest;'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+script: "phpunit -c ./test/complete.phpunit.xml"
+services: mysql
+
+# Set php versions
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
+before_script:
+  - composer install
+  - cp test/properties.travis.inc.php test/properties.inc.php
+  - mysql -e 'create database xpdotest;'
+
+before_install:
+  -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -s -o $HOME/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.9.phar; chmod +x $HOME/.phpenv/versions/5.5/bin/phpunit; fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ before_script:
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -s -o $HOME/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.9.phar; chmod +x $HOME/.phpenv/versions/5.5/bin/phpunit; fi
 
+cache:
+  directories:
+    - vendor/

--- a/test/complete.phpunit.xml
+++ b/test/complete.phpunit.xml
@@ -11,6 +11,9 @@
          syntaxCheck="false"
          bootstrap="./bootstrap.php"
         >
+    <php>
+        <env name="TEST_DRIVER" value="mysql"/>
+    </php>
     <testsuites>
         <testsuite name="Complete">
             <file>./xPDO/Test/SetUpTest.php</file>

--- a/test/properties.travis.inc.php
+++ b/test/properties.travis.inc.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use xPDO\xPDO;
+
+$properties['xpdo_test_path'] = dirname(__FILE__) . '/';
+
+/* mysql */
+$properties['mysql_string_dsn_test']= 'mysql:host=localhost;dbname=xpdotest;charset=utf8';
+$properties['mysql_string_dsn_nodb']= 'mysql:host=localhost;charset=utf8';
+$properties['mysql_string_dsn_error']= 'mysql:host= nonesuchhost;dbname=nonesuchdb';
+$properties['mysql_string_username']= 'travis';
+$properties['mysql_string_password']= '';
+$properties['mysql_array_driverOptions']= array();
+$properties['mysql_array_options']= array(
+    xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] .'cache/',
+    xPDO::OPT_HYDRATE_FIELDS => true,
+    xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
+    xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
+    xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE => true),
+    xPDO::OPT_CONNECTIONS => array(
+        array(
+            'dsn' => $properties['mysql_string_dsn_test'],
+            'username' => $properties['mysql_string_username'],
+            'password' => $properties['mysql_string_password'],
+            'options' => array(
+                xPDO::OPT_CONN_MUTABLE => true,
+            ),
+            'driverOptions' => $properties['mysql_array_driverOptions'],
+        ),
+    ),
+);
+
+/* sqlite */
+$properties['sqlite_string_dsn_test']= 'sqlite:' . $properties['xpdo_test_path'] . 'db/xpdotest';
+$properties['sqlite_string_dsn_nodb']= 'sqlite::memory:';
+$properties['sqlite_string_dsn_error']= 'sqlite:db/';
+$properties['sqlite_string_username']= '';
+$properties['sqlite_string_password']= '';
+$properties['sqlite_array_driverOptions']= array();
+$properties['sqlite_array_options']= array(
+    xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] . 'cache/',
+    xPDO::OPT_HYDRATE_FIELDS => true,
+    xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
+    xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
+    xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE => true),
+    xPDO::OPT_CONNECTIONS => array(
+        array(
+            'dsn' => $properties['sqlite_string_dsn_test'],
+            'username' => $properties['sqlite_string_username'],
+            'password' => $properties['sqlite_string_password'],
+            'options' => array(
+                xPDO::OPT_CONN_MUTABLE => true,
+            ),
+            'driverOptions' => $properties['sqlite_array_driverOptions'],
+        ),
+    ),
+);
+
+/* sqlsrv */
+$properties['sqlsrv_string_dsn_test']= 'sqlsrv:server=(local);database=xpdo_test';
+$properties['sqlsrv_string_dsn_nodb']= 'sqlsrv:server=(local)';
+$properties['sqlsrv_string_dsn_error']= 'sqlsrv:server=xyz;123';
+$properties['sqlsrv_string_username']= '';
+$properties['sqlsrv_string_password']= '';
+$properties['sqlsrv_array_driverOptions']= array(/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/);
+$properties['sqlsrv_array_options']= array(
+    xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] . 'cache/',
+    xPDO::OPT_HYDRATE_FIELDS => true,
+    xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
+    xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
+    xPDO::OPT_CONNECTIONS => array(
+        array(
+            'dsn' => $properties['sqlsrv_string_dsn_test'],
+            'username' => $properties['sqlsrv_string_username'],
+            'password' => $properties['sqlsrv_string_password'],
+            'options' => array(
+                xPDO::OPT_CONN_MUTABLE => true,
+            ),
+            'driverOptions' => $properties['sqlsrv_array_driverOptions'],
+        ),
+    ),
+);
+
+/* PHPUnit test config */
+$properties['xpdo_driver']= 'mysql';
+$properties['logLevel']= xPDO::LOG_LEVEL_INFO;
+$properties['logTarget']= php_sapi_name() === 'cli' ? 'ECHO' : 'HTML';
+//$properties['debug']= -1;
+
+return $properties;

--- a/test/properties.travis.inc.php
+++ b/test/properties.travis.inc.php
@@ -89,7 +89,7 @@ $properties['sqlsrv_array_options']= array(
 );
 
 /* PHPUnit test config */
-$properties['xpdo_driver']= 'mysql';
+$properties['xpdo_driver']= getenv('TEST_DRIVER');
 $properties['logLevel']= xPDO::LOG_LEVEL_INFO;
 $properties['logTarget']= php_sapi_name() === 'cli' ? 'ECHO' : 'HTML';
 //$properties['debug']= -1;


### PR DESCRIPTION
This will need to be set up on the modxcms/xpdo repository in travis, but the configuration will run the full test suite on every commit and pull request that comes in. It's a bit slow, due to the matrix of mysql/sqlsrv and all the different php version, but better than not running them!

Travis doesn't seem to support sqlsrv/mssql unfortunately, so this just tests the mysql and sqlite drivers. 