### PR TITLE
Wrap the output of the error log message

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2030,7 +2030,8 @@ class xPDO {
             }
             switch ($target) {
                 case 'HTML' :
-                    echo '<h5>[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ')</h5><pre>' . $msg . '</pre>' . "\n";
+                    $debugBlockClass = $this->getOption('debug_block_class',NULL,'modx-debug-block');
+                    echo '<div class="'.$debugBlockClass.'">'.'<h5>[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ')</h5><pre>' . $msg . '</pre></div>' . "\n";
                     break;
                 default :
                     echo '[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n";


### PR DESCRIPTION
### What does it do?
Wrap the output of the error log message.

### Why is it needed?
To be able to customize the HTML block of error messages if it's displayed on the page when the log target is "HTML".

### Related issue(s)/PR(s)
I think none.