### PR TITLE
Add support for container-interop DI and deprecate xPDO::getService()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/console": "^2.8"
+        "symfony/console": "^2.8",
+        "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7.0"

--- a/src/xPDO/Exception/Container/ContainerException.php
+++ b/src/xPDO/Exception/Container/ContainerException.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Exception\Container;
+
+
+class ContainerException extends \Exception implements \Interop\Container\Exception\ContainerException
+{
+
+}

--- a/src/xPDO/Exception/Container/NotFoundException.php
+++ b/src/xPDO/Exception/Container/NotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Exception\Container;
+
+
+use xPDO\xPDOException;
+
+class NotFoundException extends xPDOException implements \Interop\Container\Exception\NotFoundException {}

--- a/src/xPDO/xPDOContainer.php
+++ b/src/xPDO/xPDOContainer.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO;
+
+
+use Interop\Container\ContainerInterface;
+use xPDO\Exception\Container\ContainerException;
+use xPDO\Exception\Container\NotFoundException;
+
+/**
+ * Implements a minimal container for service location.
+ *
+ * @package xPDO
+ */
+class xPDOContainer implements ContainerInterface, \ArrayAccess
+{
+    private $entries = array();
+
+    /**
+     * Add an entry to the container with the specified identifier.
+     *
+     * @param string $id The identifier for the entry.
+     * @param mixed  $entry The entry to add.
+     */
+    public function add($id, $entry)
+    {
+        $this->offsetSet($id, $entry);
+    }
+
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws \Interop\Container\Exception\NotFoundException  No entry was found for this identifier.
+     * @throws \Interop\Container\Exception\ContainerException Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id)
+    {
+        if ($this->has($id)) {
+            try {
+                return $this->offsetGet($id);
+            } catch (\Exception $e) {
+                throw new ContainerException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+        throw new NotFoundException("Dependency not found with key {$id}.");
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return boolean
+     */
+    public function has($id)
+    {
+        return $this->offsetExists($id);
+    }
+
+    /**
+     * Whether a offset exists
+     *
+     * @link  http://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset <p>
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->entries);
+    }
+
+    /**
+     * Offset to retrieve
+     *
+     * @link  http://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to retrieve.
+     *                      </p>
+     *
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return $this->entries[$offset];
+    }
+
+    /**
+     * Offset to set
+     *
+     * @link  http://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to assign the value to.
+     *                      </p>
+     * @param mixed $value  <p>
+     *                      The value to set.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->entries[$offset] = $value;
+    }
+
+    /**
+     * Offset to unset
+     *
+     * @link  http://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to unset.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->entries[$offset]);
+    }
+}


### PR DESCRIPTION
Converts xPDO->services to a minimal container-interop DI container and allows xPDO to be constructed with any compatible DI container that implements container-interop. All xPDO configuration is expected in the container with the key `config`.