### PR TITLE
Remove all embedded escape characters when escape() is used on a string

### DIFF
--- a/test/xPDO/xPDO/xPDO.php
+++ b/test/xPDO/xPDO/xPDO.php
@@ -94,7 +94,7 @@ class xPDOTest extends xPDOTestCase {
     public function testEscape() {
     	if (!empty(xPDOTestHarness::$debug)) print "\n" . __METHOD__ . " = ";
         $correct = 'test';
-        $correct = trim($correct, $this->xpdo->_escapeCharOpen . $this->xpdo->_escapeCharClose);
+        $correct = str_replace(array($this->xpdo->_escapeCharOpen, $this->xpdo->_escapeCharClose), array(''), $correct);
         $correct = $this->xpdo->_escapeCharOpen . $correct . $this->xpdo->_escapeCharClose;
 
         $eco = $this->xpdo->_escapeCharOpen;
@@ -102,6 +102,7 @@ class xPDOTest extends xPDOTestCase {
         $this->assertEquals($correct,$this->xpdo->escape('test'),'xpdo->escape() did not correctly escape.');
         $this->assertEquals($correct,$this->xpdo->escape($eco.'test'),'xpdo->escape() did not strip the beginning escape character before escaping.');
         $this->assertEquals($correct,$this->xpdo->escape($eco.'test'.$ecc),'xpdo->escape() did not strip the beginning and end escape character before escaping.');
+        $this->assertEquals($correct,$this->xpdo->escape($eco.'t`e`s`t'.$ecc),'xpdo->escape() did not strip the embedded escape characters before escaping.');
         $this->assertEquals($correct,$this->xpdo->escape('test'.$ecc),'xpdo->escape() did not strip the end escape character before escaping.');
     }
 

--- a/xpdo/changelog.txt
+++ b/xpdo/changelog.txt
@@ -2,6 +2,7 @@ This file shows the changes in this release of xPDO.
 
 xPDO 2.6.0-pl (TBD)
 ====================================
+- Remove all embedded escape characters when escape() is used on a string
 - Make sure empty cache file does not return true in PHP format
 - Make sure FileCache uses file/folder permissions options + add optional overrides
 

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -2157,7 +2157,7 @@ class xPDO {
      * @return string The string escaped with the platform-specific escape characters.
      */
     public function escape($string) {
-        $string = trim($string, $this->_escapeCharOpen . $this->_escapeCharClose);
+        $string = str_replace(array($this->_escapeCharOpen, $this->_escapeCharClose), array(''), $string);
         return $this->_escapeCharOpen . $string . $this->_escapeCharClose;
     }
 


### PR DESCRIPTION
This prevents SQL injection potential when a value is passed with an embedded escape character for the platform.