### PR TITLE
Customize the available sql operators

### DIFF
--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -134,6 +134,12 @@ abstract class xPDOQuery extends xPDOCriteria {
                 }
             }
         }
+        if ($operators = json_decode($this->xpdo->getOption('allowed_sql_operators', null, ''))) {
+            if (is_array($operators)) $this->_operators = array_unique(array_merge($this->_operators, $operators));
+        }
+        if ($operators = json_decode($this->xpdo->getOption('denied_sql_operators', null, ''))) {
+            if (is_array($operators)) $this->_operators = array_diff($this->_operators, $operators);
+        }
     }
 
     /**


### PR DESCRIPTION
## What does it do?
It allows to manage the list of sql operators.  To do this you need to add two system settings - **allowed_sql_operators** and **denied_sql_operators**. 

## Why is it needed?
This PR give me the ability to do like that 
```
$q = $modx->newQuery('modResource');
$q->where('FIND_IN_SET("' . $tag . '",`tags`)'); // FIND_IN_SET is not included in the allowed sql operator list by default
```
All I need is to set the **allowed_sql_operators** system setting in JSON format: ["FIND_IN_SET", "ANOTHER_SQL_OPERATOR"]

P.S. It also simplifies the usage of the pdoTools library:
```
[[!pdoResources?
    &where=`{ "parent":2, "0":"FIND_IN_SET({$tag}, `tags`)" }`
]]
```

## Related issue(s)/PR(s)
?