### PR TITLE
Correctly handle fetching all config settings from ContainerInterface

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -347,7 +347,7 @@ class xPDO {
         if ($data instanceof ContainerInterface) {
             $this->services = $data;
             if ($this->services->has('config')) {
-                $data = $this->services->get('config');
+                $data = $this->services->get('config')->all();
             }
         }
         if (!is_array($data)) {


### PR DESCRIPTION
Fixes error in xPDO where passing an instance of ContainerInterface does it correctly fetch the config array.