### PR TITLE
Allow loading of namespaced classes

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -650,7 +650,7 @@ class xPDO {
         if (empty($path)) $path= XPDO_CORE_PATH;
         if (!$included) {
             /* turn to filesystem path and enforce all lower-case paths and filenames */
-            $fqcn= str_replace('.', '/', $fqn) . '.class.php';
+            $fqcn= str_replace(['.','\\'], '/', $fqn) . '.class.php';
             /* include class */
             if (!file_exists($path . $fqcn)) return false;
             if (!$rt= include_once ($path . $fqcn)) {


### PR DESCRIPTION
This makes it possible to load classes with a (lowercase!) namespace.

E.g. 
```
$modx->getService('myservicename', 'custom\Base', '/core/components/custom/model/');
```
which would now load the class `Base` in the `custom` namespace from `/core/components/custom/model/custom/base.class.php`.

Before it would fail by searching for the class at `/core/components/custom/model/custom\base.class.php` (notice the `\` instead of `/`)