### PR TITLE
Resolve unlink() error

### DIFF
--- a/src/xPDO/Cache/xPDOCacheManager.php
+++ b/src/xPDO/Cache/xPDOCacheManager.php
@@ -495,10 +495,12 @@ class xPDOCacheManager {
                             }
                             elseif (is_file($path)) {
                                 if (is_array($extensions) && !empty($extensions) && !$this->endsWith($file, $extensions)) continue;
-                                if (unlink($path)) {
-                                    array_push($result, $path);
-                                } else {
-                                    $hasMore= true;
+                                if(file_exists($path)){
+                                    if (unlink($path)) {
+                                        array_push($result, $path);
+                                    } else {
+                                        $hasMore= true;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
What does it do?

Wrapped the unlink($file) call in an if statement to confirm that $file still exists.

Why is it needed?

Resolves unlink() errors that occur when concurrent requests for a cache file results in one unlink() call being successful while other unlink() calls result in a PHP error being thrown.

Related issue(s)/PR(s)

None to my knowledge