### PR TITLE
Make error.log location customizable

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -2076,8 +2076,10 @@ class xPDO {
         $content= @ob_get_contents();
         @ob_end_clean();
         if ($target=='FILE' && $this->getCacheManager()) {
-            $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
-            $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
+            $defaultFilename = $this->getOption('error_log_filename', null, 'error.log', true);
+            $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : $defaultFilename;
+            $defaultFilepath = $this->getOption('error_log_path', null, $this->getCachePath() . xPDOCacheManager::LOG_DIR, true);
+            $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $defaultFilepath;
             $this->cacheManager->writeFile($filepath . $filename, $content, 'a');
         } elseif ($target=='ARRAY' && isset($targetOptions['var']) && is_array($targetOptions['var'])) {
             $targetOptions['var'][] = $content;


### PR DESCRIPTION
### What does it do?
Adds 2 new system settings for specifying the error log filename and path.

### Why is it needed?
This makes it possible to fully customize the location of the MODX error log. Now one could move the error log outside of the MODX directory and name it modx.log.

### Related issue(s)/PR(s)
Issue: #13752
MODX PR: https://github.com/modxcms/revolution/pull/13763
