### PR TITLE
Replace all deprecated while/each() loops with foreach() loops

### DIFF
--- a/src/xPDO/Cache/xPDOCacheManager.php
+++ b/src/xPDO/Cache/xPDOCacheManager.php
@@ -595,7 +595,7 @@ class xPDOCacheManager {
             $source= "\${$objName}= \${$objRef}->newObject('{$className}');\n";
             $source .= "\${$objName}->fromArray(" . var_export($obj->toArray('', true), true) . ", '', true, true);\n";
             if ($generateObjVars && $objectVars= get_object_vars($obj)) {
-                while (list($vk, $vv)= each($objectVars)) {
+                foreach ($objectVars as $vk => $vv) {
                     if ($vk === 'modx') {
                         $source .= "\${$objName}->{$vk}= & \${$objRef};\n";
                     }

--- a/src/xPDO/Om/mysql/xPDOQuery.php
+++ b/src/xPDO/Om/mysql/xPDOQuery.php
@@ -74,9 +74,8 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
         }
         if ($command == 'UPDATE') {
             if (!empty($this->query['set'])) {
-                reset($this->query['set']);
                 $clauses = array();
-                while (list($setKey, $setVal) = each($this->query['set'])) {
+                foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
                     if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {

--- a/src/xPDO/Om/sqlite/xPDOQuery.php
+++ b/src/xPDO/Om/sqlite/xPDOQuery.php
@@ -74,9 +74,8 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
         }
         if ($command == 'UPDATE') {
             if (!empty($this->query['set'])) {
-                reset($this->query['set']);
                 $clauses = array();
-                while (list($setKey, $setVal) = each($this->query['set'])) {
+                foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
                     if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {

--- a/src/xPDO/Om/sqlsrv/xPDOQuery.php
+++ b/src/xPDO/Om/sqlsrv/xPDOQuery.php
@@ -10,6 +10,9 @@
 
 namespace xPDO\Om\sqlsrv;
 
+use xPDO\Om\xPDOQueryCondition;
+use xPDO\xPDO;
+
 /**
  * An implementation of xPDOQuery for the sqlsrv database driver.
  *
@@ -41,7 +44,7 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                     $field['sql']= $this->xpdo->escape($alias) . '.' . $this->xpdo->escape($k) . " = ?";
                     $field['binding']= array (
                         'value' => $conditions[$iteration],
-                        'type' => $isString ? PDO::PARAM_STR : PDO::PARAM_INT,
+                        'type' => $isString ? \PDO::PARAM_STR : \PDO::PARAM_INT,
                         'length' => 0
                     );
                     $field['conjunction']= $conjunction;
@@ -49,8 +52,7 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                     $iteration++;
                 }
             } else {
-                reset($conditions);
-                while (list ($key, $val)= each($conditions)) {
+                foreach ($conditions as $key => $val) {
                     if (is_int($key)) {
                         if (is_array($val)) {
                             $result[]= $this->parseConditions($val, $conjunction);
@@ -82,25 +84,25 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                             $key= $key_parts[1];
                         }
                         if ($val === null) {
-                            $type= PDO::PARAM_NULL;
+                            $type= \PDO::PARAM_NULL;
                             if (!in_array($operator, array('IS', 'IS NOT'))) {
                                 $operator= $operator === '!=' ? 'IS NOT' : 'IS';
                             }
                         }
                         elseif (isset($fieldMeta[$key]) && !in_array($fieldMeta[$key]['phptype'], $this->_quotable)) {
-                            $type= PDO::PARAM_INT;
+                            $type= \PDO::PARAM_INT;
                         }
                         else {
-                            $type= PDO::PARAM_STR;
+                            $type= \PDO::PARAM_STR;
                         }
                         if (in_array(strtoupper($operator), array('IN', 'NOT IN')) && is_array($val)) {
                             $vals = array();
                             foreach ($val as $v) {
                                 switch ($type) {
-                                    case PDO::PARAM_INT:
+                                    case \PDO::PARAM_INT:
                                         $vals[] = (integer) $v;
                                         break;
-                                    case PDO::PARAM_STR:
+                                    case \PDO::PARAM_STR:
                                         $vals[] = $this->xpdo->quote($v);
                                         break;
                                     default:
@@ -119,7 +121,7 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                             }
                         }
                         $field= array ();
-                        if ($type === PDO::PARAM_NULL) {
+                        if ($type === \PDO::PARAM_NULL) {
                             $field['sql']= $this->xpdo->escape($alias) . '.' . $this->xpdo->escape($key) . ' ' . $operator . ' NULL';
                             $field['binding']= null;
                             $field['conjunction']= $conj;
@@ -146,9 +148,9 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
         }
         elseif (($pktype == 'integer' && is_numeric($conditions)) || ($pktype == 'string' && is_string($conditions))) {
             if ($pktype == 'integer') {
-                $param_type= PDO::PARAM_INT;
+                $param_type= \PDO::PARAM_INT;
             } else {
-                $param_type= PDO::PARAM_STR;
+                $param_type= \PDO::PARAM_STR;
             }
             $field['sql']= $this->xpdo->escape($alias) . '.' . $this->xpdo->escape($pk) . ' = ?';
             $field['binding']= array ('value' => $conditions, 'type' => $param_type, 'length' => 0);
@@ -243,12 +245,11 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
         }
         if ($command == 'UPDATE') {
             if (!empty($this->query['set'])) {
-                reset($this->query['set']);
                 $clauses = array();
-                while (list($setKey, $setVal) = each($this->query['set'])) {
+                foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
-                    if ($value !== null && in_array($type, array(PDO::PARAM_INT, PDO::PARAM_STR))) {
+                    if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
                         $value = $this->xpdo->quote($value, $type);
                     } elseif ($value === null) {
                         $value = 'NULL';

--- a/src/xPDO/Om/xPDOCriteria.php
+++ b/src/xPDO/Om/xPDOCriteria.php
@@ -82,8 +82,7 @@ class xPDOCriteria {
             $this->bindings= array_merge($this->bindings, $bindings);
         }
         if (is_object($this->stmt) && $this->stmt && !empty ($this->bindings)) {
-            reset($this->bindings);
-            while (list ($key, $val)= each($this->bindings)) {
+            foreach ($this->bindings as $key => $val) {
                 if (is_array($val)) {
                     $type= isset ($val['type']) ? $val['type'] : \PDO::PARAM_STR;
                     $length= isset ($val['length']) ? $val['length'] : 0;

--- a/src/xPDO/Om/xPDOGenerator.php
+++ b/src/xPDO/Om/xPDOGenerator.php
@@ -164,7 +164,7 @@ abstract class xPDOGenerator {
     public function getClassName($string) {
         if (is_string($string) && $strArray= explode('_', $string)) {
             $return= '';
-            while (list($k, $v)= each($strArray)) {
+            foreach ($strArray as $k => $v) {
                 $return.= strtoupper(substr($v, 0, 1)) . substr($v, 1) . '';
             }
             $string= $return;
@@ -814,32 +814,32 @@ EOD;
         $meta['phpdoc-properties'] = $this->_constructPhpDocProperties($this->map[$meta['class']]);
         $meta['phpdoc-end'] = $this->_constructPhpDpcEnd($class, $meta);
     }
-    
+
     protected function _constructPhpDocStart($class, $meta) {
         $output = array(
             '/**'
         );
         $output[] = ' * Class ' . $meta['class-shortname'];
-        
+
         return implode(PHP_EOL, $output);
     }
-    
+
     protected function _constructPhpDpcEnd($class, $meta) {
         $output = array(
             ' *'
         );
-        
+
         $output[] = ' * @package ' . $meta['namespace'];
         $output[] = ' */';
 
         return implode(PHP_EOL, $output);
     }
-    
+
     protected function _constructPhpDocProperties($meta) {
         $properties = array(
             ' *'
         );
-        
+
         if ($this->manager->xpdo->getOption(xPDO::OPT_HYDRATE_FIELDS)) {
             foreach ($meta['fieldMeta'] as $field => $def) {
                 $type = $def['phptype'];
@@ -853,7 +853,7 @@ EOD;
                         $type = 'array';
                         break;
                 }
-                
+
                 $properties[] = ' * @property ' . $type . ' $' . $field;
             }
         }
@@ -865,7 +865,7 @@ EOD;
                     $properties[] = ' * @property ' . '\\' . ltrim($def['class'], '\\') . (($def['cardinality'] == 'many') ? '[]' : '') . ' $' . $field;
                 }
             }
-        
+
             if (isset($meta['aggregations'])) {
                 $properties[] = ' *';
                 foreach ($meta['aggregations'] as $field => $def) {
@@ -873,7 +873,7 @@ EOD;
                 }
             }
         }
-        
+
         return implode(PHP_EOL, $properties);
     }
 

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -2021,8 +2021,7 @@ class xPDOObject {
         if (is_array($fldarray)) {
             $pkSet= false;
             $generatedKey= false;
-            reset($fldarray);
-            while (list ($key, $val)= each($fldarray)) {
+            foreach ($fldarray as $key => $val) {
                 if (!empty ($keyPrefix)) {
                     $prefixPos= strpos($key, $keyPrefix);
                     if ($prefixPos === 0) {
@@ -2270,8 +2269,7 @@ class xPDOObject {
      * @access protected
      */
     protected function _initFields() {
-        reset($this->_fieldMeta);
-        while (list ($k, $v)= each($this->_fieldMeta)) {
+        foreach ($this->_fieldMeta as $k => $v) {
             $this->fieldNames[$k]= $this->xpdo->escape($this->_table) . '.' . $this->xpdo->escape($k);
         }
     }

--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -246,8 +246,7 @@ abstract class xPDOQuery extends xPDOCriteria {
     public function set(array $values) {
         $fieldMeta= $this->xpdo->getFieldMeta($this->_class);
         $fieldAliases= $this->xpdo->getFieldAliases($this->_class);
-        reset($values);
-        while (list($key, $value) = each($values)) {
+        foreach ($values as $key => $value) {
             $type= null;
             if (!array_key_exists($key, $fieldMeta)) {
                 if (array_key_exists($key, $fieldAliases)) {
@@ -633,7 +632,7 @@ abstract class xPDOQuery extends xPDOCriteria {
             }
         }
         if (!empty($relations) && $relObj instanceof xPDOObject) {
-            while (list($relationAlias, $subRelations)= each($relations)) {
+            foreach ($relations as $relationAlias => $subRelations) {
                 if (is_array($subRelations) && !empty($subRelations)) {
                     foreach ($subRelations as $subRelation) {
                         $this->hydrateGraphNode($row, $relObj, $relationAlias, $subRelation);
@@ -709,8 +708,7 @@ abstract class xPDOQuery extends xPDOCriteria {
                     $iteration++;
                 }
             } else {
-                reset($conditions);
-                while (list ($key, $val)= each($conditions)) {
+                foreach ($conditions as $key => $val) {
                     if (is_int($key)) {
                         if (is_array($val)) {
                             $result[]= $this->parseConditions($val, $conjunction);

--- a/src/xPDO/Transport/xPDOVehicle.php
+++ b/src/xPDO/Transport/xPDOVehicle.php
@@ -120,7 +120,7 @@ abstract class xPDOVehicle {
     public function resolve(& $transport, & $object, $options = array ()) {
         $resolved = false;
         if (isset ($this->payload['resolve'])) {
-            while (list ($rKey, $r) = each($this->payload['resolve'])) {
+            foreach ($this->payload['resolve'] as $rKey => $r) {
                 $type = $r['type'];
                 $body = $r['body'];
                 $preExistingMode = xPDOTransport::PRESERVE_PREEXISTING;
@@ -242,7 +242,7 @@ abstract class xPDOVehicle {
     public function validate(& $transport, & $object, $options = array ()) {
         $validated = true;
         if (isset ($this->payload['validate'])) {
-            while (list ($rKey, $r) = each($this->payload['validate'])) {
+            foreach ($this->payload['validate'] as $rKey => $r) {
                 $type = $r['type'];
                 $body = $r['body'];
                 switch ($type) {

--- a/test/xPDO/Legacy/Om/xPDOObjectSingleTableInheritanceTest.php
+++ b/test/xPDO/Legacy/Om/xPDOObjectSingleTableInheritanceTest.php
@@ -311,7 +311,7 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
         try {
             $object = $this->xpdo->getObject("sti.baseClass", $criteria);
             if ($object) {
-                while (list($key, $value) = each($update)) {
+                foreach ($update as $key => $value) {
                     $object->set($key, $value);
                 }
                 $result = $object->save();

--- a/test/xPDO/Test/Compression/xPDOZipTest.php
+++ b/test/xPDO/Test/Compression/xPDOZipTest.php
@@ -84,7 +84,7 @@ class xPDOZipTest extends TestCase
         try {
             $zip = new xPDOZip($this->xpdo, $archivePath, $options);
             $result = $zip->pack($sourcePath, $packOptions);
-            while (list($idx, $entry) = each($result)) $result[$idx] = str_replace($sourcePath, $source, $entry);
+            foreach ($result as $idx => $entry) $result[$idx] = str_replace($sourcePath, $source, $entry);
             $this->xpdo->log(xPDO::LOG_LEVEL_INFO, "Pack results for {$archive}: " . print_r($result, true));
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);

--- a/test/xPDO/Test/Om/xPDOObjectSingleTableInheritanceTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectSingleTableInheritanceTest.php
@@ -314,7 +314,7 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
         try {
             $object = $this->xpdo->getObject("xPDO\\Test\\Sample\\STI\\baseClass", $criteria);
             if ($object) {
-                while (list($key, $value) = each($update)) {
+                foreach ($update as $key => $value) {
                     $object->set($key, $value);
                 }
                 $result = $object->save();

--- a/tools/schema/upgrade-mysql-1.1.php
+++ b/tools/schema/upgrade-mysql-1.1.php
@@ -119,7 +119,7 @@ if (!empty($argv) && $argc > 1) {
     }
 } elseif (!empty($_REQUEST)) {
     /* process $_REQUEST arguments */
-    while (list($argKey, $argValue)= each($_REQUEST)) {
+    foreach ($_REQUEST as $argKey => $argValue) {
         if (in_array(strtolower($argValue), array('true','false'))) {
             $argValue = $argValue === 'true' ? true : false;
         }


### PR DESCRIPTION
The each() function is deprecated in PHP 7.2 and this will solve the deprecated warnings.

Resolves issue #132.