### PR TITLE
Fixes for sqlsrv compatibility

### DIFF
--- a/src/xPDO/Om/sqlsrv/xPDOGenerator.php
+++ b/src/xPDO/Om/sqlsrv/xPDOGenerator.php
@@ -141,9 +141,8 @@ class xPDOGenerator extends \xPDO\Om\xPDOGenerator {
             //INDEXES
             $indicesStmt= $this->manager->xpdo->query("
 			  SELECT
-			    i.*,ic.*
+			    i.*
   			  FROM sys.indexes i
-			  LEFT JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
 			  WHERE i.object_id = '{$tableId}'
 			");
 
@@ -158,9 +157,10 @@ class xPDOGenerator extends \xPDO\Om\xPDOGenerator {
                 //INDEX COLUMNS
                 $columnsStmt = $this->manager->xpdo->query("
 			      SELECT
-	   		      col.*
-  			      FROM sys.columns col
-			      WHERE col.object_id = '{$index['object_id']}' AND col.column_id = '{$index['column_id']}'
+				  ic.*,col.*
+				  FROM sys.index_columns ic
+				  LEFT JOIN sys.columns col ON ic.column_id = col.column_id
+			      WHERE ic.object_id = '{$tableId}' AND col.object_id = '{$tableId}' AND ic.index_id = '{$index['index_id']}'
 			    ");
                 $columns = $columnsStmt->fetchAll(PDO::FETCH_ASSOC);
                 if ($this->manager->xpdo->getDebug() === true) $this->manager->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Columns of index {$index['name']}: " . print_r($columns, true));

--- a/src/xPDO/Om/sqlsrv/xPDOQuery.php
+++ b/src/xPDO/Om/sqlsrv/xPDOQuery.php
@@ -227,15 +227,15 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
         $tables= array ();
         foreach ($this->query['from']['tables'] as $table) {
             if ($command != 'SELECT') {
-                $tables[]= $this->xpdo->escape($table['table']);
+                $tables[]= $this->xpdo->escape($table['table_prefix']).'.'.$this->xpdo->escape(str_replace(array('[',']',$table['table_prefix']),'',$table['table']));
             } else {
-                $tables[]= $this->xpdo->escape($table['table']) . ' AS ' . $this->xpdo->escape($table['alias']);
+                $tables[]= $this->xpdo->escape($table['table_prefix']).'.'.$this->xpdo->escape(str_replace(array('[',']',$table['table_prefix']),'',$table['table'])) . ' AS ' . $this->xpdo->escape($table['alias']);
             }
         }
         $sql.= $this->query['from']['tables'] ? implode(', ', $tables) . ' ' : '';
         if (!empty ($this->query['from']['joins'])) {
             foreach ($this->query['from']['joins'] as $join) {
-                $sql.= $join['type'] . ' ' . $this->xpdo->escape($join['table']) . ' AS ' . $this->xpdo->escape($join['alias']) . ' ';
+                $sql.= $join['type'] . ' ' . $this->xpdo->escape($join['table_prefix']).'.'.$this->xpdo->escape(str_replace(array('[',']',$join['table_prefix']),'',$join['table'])) . ' AS ' . $this->xpdo->escape($join['alias']) . ' ';
                 if (!empty ($join['conditions'])) {
                     $sql.= 'ON ';
                     $sql.= $this->buildConditionalClause($join['conditions']);

--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -123,7 +123,8 @@ abstract class xPDOQuery extends xPDOCriteria {
             $this->_tableClass = $this->xpdo->getTableClass($this->_class);
             $this->query['from']['tables'][0]= array (
                 'table' => $this->xpdo->getTableName($this->_class),
-                'alias' => & $this->_alias
+                'alias' => & $this->_alias,
+                'table_prefix' => $this->xpdo->getOption('table_prefix')
             );
             if ($criteria !== null) {
                 if (is_object($criteria)) {
@@ -296,6 +297,7 @@ abstract class xPDOQuery extends xPDOCriteria {
             $targetIdx= count($target);
             $target[$targetIdx]= array (
                 'table' => $this->xpdo->getTableName($class),
+                'table_prefix' => $this->xpdo->getOption('table_prefix'),
                 'class' => $class,
                 'alias' => $alias,
                 'type' => $type,


### PR DESCRIPTION
### Summary
Gets `writeSchema()` working and addresses issue with escaped table prefixes/names format in queries for sqlsrv.
### Reason
Schema file generation and all queries using a model were failing.
### Notes
This is a first attempt to fix sqlsrv compatibility so all comments welcome.

Due to the table prefix/name escaping required for sqlsrv, currently you need to specify a `$tablePrefix` and set `$restrictPrefix` to `true` in the `writeSchema()` call. Then set the table prefix in your `setPackage()` call. This could be improved.

### Environment
Database:
- MS SQL Server 2008 R2

Application:
- Centos 7
- PHP Version 7.0.30
- PDO driver: sqlsrv