### PR TITLE
Migrations for xPDO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # ignore composer.lock
 composer.lock
+/src/xPDO/Migrations/log/version.log

--- a/README.md
+++ b/README.md
@@ -54,3 +54,27 @@ $xpdoSQLite = \xPDO\xPDO::getInstance('aSQLiteDatabase', [
     ],
 ]);
 ```
+
+## Migrations
+
+1. Copy properties.sample.inc.php to be properties.inc.php and set for your DB.
+2. SSH or in your terminal CD to the xPDO directory
+3. Then run ```php bin/xpdo.php``` to see the list of commands
+4. Run the mig-install command like so: ```php bin/xpdo.php xpdo:mig-install```
+5. Once installed you can generate a blank migration file run: ```php bin/xpdo.php xpdo:mig-generate``` it will tell you what directory it is in
+6. Once you have a completed migraiton file you can run all migrations or a single one by passing the name option.
+```php bin/xpdo.php xpdo:mig-run``` would run all.
+
+### Configuration options in properties.inc.php
+
+Optionally define any of the following constants 
+
+- XPDO_CONSOLE_COMMAND_NAMESPACE
+- XPDO_MIGRATION_DIR
+- XPDO_SEEDS_DIR
+
+## Example to Generate the Migrations xPDO model:
+
+Note the migration model already exists but the example exists if you need to generate your own model, just change the path.
+1. cd to xPDO project root
+2. ```php bin/xpdo xpdo:parse-schema mysql src/xPDO/Migrations/Model/schema/migrations.mysql.schema.xml  src/ --psr4=PSR4```

--- a/src/xPDO/Console/Application.php
+++ b/src/xPDO/Console/Application.php
@@ -1,8 +1,14 @@
 <?php
 namespace xPDO\Console;
 
+use xPDO\Console\Command\BaseCommand;
+use xPDO\Console\Command\MigrationGenerate;
+use xPDO\Console\Command\Migrate;
+use xPDO\Console\Command\MigrationInstall;
 use xPDO\Console\Command\ParseSchema;
+use xPDO\Console\Command\MigrationUpdate;
 use xPDO\Console\Command\WriteSchema;
+use xPDO\xPDOException;
 
 class Application extends \Symfony\Component\Console\Application
 {
@@ -15,7 +21,30 @@ class Application extends \Symfony\Component\Console\Application
 
     public function loadCommands()
     {
-        $this->add(new ParseSchema());
-        $this->add(new WriteSchema());
+        // allow user to set in config a namespace to console commands, example adding in xpdo: xpdo:write-schema
+        $console_namespace = 'xpdo';
+        if (defined('XPDO_CONSOLE_COMMAND_NAMESPACE')) {
+            $console_namespace = XPDO_CONSOLE_COMMAND_NAMESPACE;
+        }
+        $this->add((new ParseSchema())->setNameSpace($console_namespace));
+        $this->add((new WriteSchema())->setNamespace($console_namespace));
+
+        try {
+            $installed = BaseCommand::isXPDOMigrationsInstalled();
+            if (!$installed) {
+                $this->add((new MigrationInstall())->setNamespace($console_namespace));
+
+            } elseif (BaseCommand::isXPDOMigrationsRequireUpdate()) {
+                $this->add((new MigrationUpdate())->setNamespace($console_namespace));
+
+            } else {
+                // run migration
+                $this->add((new Migrate())->setNamespace($console_namespace));
+                $this->add((new MigrationGenerate())->setNamespace($console_namespace));
+            }
+
+        } catch (xPDOException $exception) {
+            echo $exception->getMessage().PHP_EOL;
+        }
     }
 }

--- a/src/xPDO/Console/Command/BaseCommand.php
+++ b/src/xPDO/Console/Command/BaseCommand.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace xPDO\Console\Command;
+
+use xPDO\Helpers\ConsoleUserInteractionHandler;
+use xPDO\Helpers\EmptyUserInteractionHandler;
+use xPDO\Migrations\Migrator;
+use xPDO\xPDO;
+use xPDO\xPDOException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+
+
+/**
+ * Class BaseCommand
+ * @package xPDO\Console\Command
+ */
+abstract class BaseCommand extends Command
+{
+    /** @var xPDO */
+    protected $xpdo;
+
+    /** @var \xPDO\Migrations\Migrator */
+    protected $migrator;
+
+    /** @var \xPDO\Helpers\ConsoleUserInteractionHandler */
+    protected $consoleUserInteractionHandler;
+
+    /** \Symfony\Component\Console\Input\InputInterface $input */
+    protected $input;
+
+    /** \Symfony\Component\Console\Output\OutputInterface $output */
+    protected $output;
+
+    protected $startTime;
+
+    /**
+     * Initializes the command just after the input has been validated.
+     *
+     * This is mainly useful when a lot of commands extends one main command
+     * where some things need to be initialized based on the input arguments and options.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->startTime = microtime(true);
+        $this->input = $input;
+        $this->output = $output;
+
+        $this->consoleUserInteractionHandler = new ConsoleUserInteractionHandler($input, $output);
+        $this->consoleUserInteractionHandler->setCommandObject($this);
+
+        try {
+            $config = $input->getOption('config');
+        } catch (InvalidArgumentException $exception) {
+            $config = [];
+        }
+        $properties = $this->loadConfig($output, $config);
+        if ($properties === false) {
+            $output->writeln('fatal: no valid configuration file could be loaded');
+            return;
+        }
+
+        try {
+            $platform = strtolower($input->getArgument('platform'));
+        } catch (InvalidArgumentException $exception) {
+            try {
+                $platform = strtolower($input->getOption('platform'));
+            } catch (InvalidArgumentException $exception) {
+                $platform = $properties['xpdo_driver'];
+            }
+        }
+
+        if (!in_array($platform, self::$platforms)) {
+            $output->writeln("fatal: no valid platform specified");
+            return;
+        }
+
+        try {
+            $this->xpdo = xPDO::getInstance('generator', $properties["{$platform}_array_options"]);
+        } catch (xPDOException $exception) {
+            $output->writeln('Error: ' . $exception->getMessage());
+            exit();
+        }
+    }
+
+    /**
+     * @param array $config
+     * @return Migrator
+     */
+    protected function getMigrator($config=[])
+    {
+        if (defined('XPDO_MIGRATION_DIR')) {
+            $config['xpdo_migration_dir'] = XPDO_MIGRATION_DIR;
+        }
+        if (defined('XPDO_SEEDS_DIR')) {
+            $config['xpdo_seeds_dir'] = XPDO_SEEDS_DIR;
+        }
+
+        $this->migrator = new Migrator(
+            $this->xpdo,
+            $this->consoleUserInteractionHandler,
+            $config
+        );
+
+        return $this->migrator;
+    }
+
+    /**
+     * @return xPDO
+     * @throws \xPDO\xPDOException
+     */
+    public static function loadXPDO()
+    {
+        $properties = self::loadConfig(new ConsoleOutput());
+        $platform = $properties['xpdo_driver'];
+
+        return xPDO::getInstance('generator', $properties["{$platform}_array_options"]);
+    }
+
+    /**
+     * @return bool
+     * @throws \xPDO\xPDOException
+     */
+    public static function isXPDOMigrationsInstalled()
+    {
+        $migrator = new Migrator(self::loadXPDO(), new EmptyUserInteractionHandler(), []);
+        return $migrator->isXPDOMigrationsInstalled();
+    }
+
+    /**
+     * @return bool
+     * @throws \xPDO\xPDOException
+     */
+    public static function isXPDOMigrationsRequireUpdate()
+    {
+        $migrator = new Migrator(self::loadXPDO(), new EmptyUserInteractionHandler(), []);
+        return $migrator->requireUpdate();
+    }
+
+
+
+    /**
+     * @return string
+     */
+    public function getRunStats()
+    {
+        $curTime = microtime(true);
+        $duration = $curTime - $this->startTime;
+
+        $output = 'Time: ' . number_format($duration * 1000, 0) . 'ms | ';
+        $output .= 'Memory Usage: ' . $this->convertBytes(memory_get_usage(false)) . ' | ';
+        $output .= 'Peak Memory Usage: ' . $this->convertBytes(memory_get_peak_usage(false));
+        return $output;
+    }
+
+    /**
+     * @param $bytes
+     * @return string
+     */
+    protected function convertBytes($bytes)
+    {
+        $unit = array('b','kb','mb','gb','tb','pb');
+        return @round($bytes/pow(1024,($i=floor(log($bytes,1024)))),2).' '.$unit[$i];
+    }
+}

--- a/src/xPDO/Console/Command/Command.php
+++ b/src/xPDO/Console/Command/Command.php
@@ -6,13 +6,21 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Command extends \Symfony\Component\Console\Command\Command
 {
+    /** @var string $namespace ~ for the command */
+    protected $namespace = '';
+
     protected static $platforms = [
         'mysql', 
         'sqlite', 
         'sqlsrv'
     ];
-    
-    protected function loadConfig(OutputInterface $output, $config = null)
+
+    /**
+     * @param OutputInterface $output
+     * @param null $config
+     * @return bool|mixed
+     */
+    protected static function loadConfig(OutputInterface $output, $config = null)
     {
         if (empty($config) || !is_readable($config)) {
             $config = false;
@@ -47,4 +55,32 @@ class Command extends \Symfony\Component\Console\Command\Command
 
         return false;
     }
+
+    /**
+     * @param $namespace
+     * @return $this
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        if (!empty($this->getName())) {
+            $this->setFullName($this->getName());
+        }
+        return $this;
+    }
+
+    /**
+     * @param $name
+     * @return $this
+     */
+    public function setFullName($name)
+    {
+        if (!empty($this->namespace)) {
+            $name = $this->namespace . ':'.$name;
+        }
+        $this->setName($name);
+        return $this;
+    }
+
+
 }

--- a/src/xPDO/Console/Command/Migrate.php
+++ b/src/xPDO/Console/Command/Migrate.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: joshgulledge
+ * Date: 2/15/18
+ * Time: 3:23 PM
+ */
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use xPDO\xPDO;
+use xPDO\xPDOException;
+use xPDO\Migrations\Migrator;
+
+class Migrate extends BaseCommand
+{
+
+    /**
+     * @see https://symfony.com/doc/current/console.html
+     *
+     */
+    protected function configure()
+    {
+        $this
+            ->setFullName('mig-run')
+            ->setDescription('Run xPDO Data migrations')
+            ->addOption(
+                'name',
+                'N',
+                InputOption::VALUE_OPTIONAL,
+                'The name of the migration file to run. Or when used with the -g option, name the generated migration file'
+            )
+            ->addOption(
+                'method',
+                'm',
+                InputOption::VALUE_OPTIONAL,
+                'Up or down(rollback), default is up',
+                'up'
+            )
+            ->addOption(
+                'id',
+                'i',
+                InputOption::VALUE_OPTIONAL,
+                'ID of migration to run'
+            )
+            ->addOption(
+                'count',
+                'c',
+                InputOption::VALUE_OPTIONAL,
+                'How many to rollback when using the [--method down] option, default is 1'
+            )
+            ->addOption(
+                'type',
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Server type to run migrations as, default is master. Possible master, staging, dev and local',
+                'master'
+            )
+            ->addOption(
+                'config',
+                'C',
+                InputOption::VALUE_REQUIRED,
+                'A path to a config file'
+            )
+            ->addOption(
+                'platform',
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'The PDO platform being targeted, e.g. mysql, sqlite, etc.',
+                'mysql'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = (string)$input->getOption('name');
+        $type = (string)$input->getOption('type');
+        $id = $input->getOption('id');
+        $count = $input->getOption('count');
+
+        $method = $input->getOption('method');
+
+        $this->getMigrator();
+
+        $this->migrator->runMigration($method, $type, $count, $id, $name);
+    }
+}

--- a/src/xPDO/Console/Command/MigrationGenerate.php
+++ b/src/xPDO/Console/Command/MigrationGenerate.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use xPDO\xPDO;
+use xPDO\xPDOException;
+use xPDO\Migrations\Migrator;
+
+class MigrationGenerate extends BaseCommand
+{
+
+    /**
+     * @see https://symfony.com/doc/current/console.html
+     *
+     */
+    protected function configure()
+    {
+        $this
+            ->setFullName('mig-generate')
+            ->setDescription('Generate an xPDO Data migration file')
+            ->addOption(
+                'name',
+                'N',
+                InputOption::VALUE_OPTIONAL,
+                'The name of the migration file to generate, will be prefixed with date(\'Y_m_d_His\').'
+            )
+            ->addOption(
+                'description',
+                'd',
+                InputOption::VALUE_OPTIONAL,
+                'Optional description of this migration file',
+                ''
+            )
+            ->addOption(
+                'ver',
+                'R',
+                InputOption::VALUE_OPTIONAL,
+                'Optional set a version number for the generated migration file. Example: 1.0.0',
+                ''
+            )
+            ->addOption(
+                'type',
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Server type, will only run migration with same type. Possible master, staging, dev and local',
+                'master'
+            )
+            ->addOption(
+                'log',
+                'l',
+                InputOption::VALUE_OPTIONAL,
+                '[1/0] Log created migration file to DB.',
+                '1'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = (string)$input->getOption('name');
+        $description = (string)$input->getOption('description');
+        $server_type = (string)$input->getOption('type');
+        $version = (string)$input->getOption('ver');
+        $log = (bool)$input->getOption('log');
+
+        $this->getMigrator();
+
+        $this->migrator->createBlankMigrationClassFile($name, $description, $version, $server_type, $log);
+    }
+}

--- a/src/xPDO/Console/Command/MigrationInstall.php
+++ b/src/xPDO/Console/Command/MigrationInstall.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MigrationInstall extends BaseCommand
+{
+    /**
+     * @see https://symfony.com/doc/current/console.html
+     * namespace:project/extra(-sub-part) verb (GET/POST/DELETE) --options
+     */
+    protected function configure()
+    {
+        $this
+            ->setFullName('mig-install')
+            ->setDescription('Please install Migrations');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getMigrator();
+
+        $output->writeln('Install ... ');
+        $this->migrator->install('up', true);
+    }
+}

--- a/src/xPDO/Console/Command/MigrationUninstall.php
+++ b/src/xPDO/Console/Command/MigrationUninstall.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MigrationUninstall extends BaseCommand
+{
+    /**
+     * @see https://symfony.com/doc/current/console.html
+     * namespace:project/extra(-sub-part) verb (GET/POST/DELETE) --options
+     */
+    protected function configure()
+    {
+        $this
+            ->setFullName('mig-uninstall')
+            ->setDescription('Uninstall Migrations');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getMigrator();
+        $this->migrator->install('down', true);
+    }
+}

--- a/src/xPDO/Console/Command/MigrationUpdate.php
+++ b/src/xPDO/Console/Command/MigrationUpdate.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MigrationUpdate extends BaseCommand
+{
+    protected $exe_type = 'install';
+
+    /**
+     * @see https://symfony.com/doc/current/console.html
+     * namespace:project/extra(-sub-part) verb (GET/POST/DELETE) --options
+     */
+    protected function configure()
+    {
+        $this->exe_type = 'update';
+        $this
+            ->setFullName('mig-update')
+            ->setDescription('An update to Migrations is required')
+            ->addArgument(
+                'update',
+                InputArgument::OPTIONAL,
+                'Set to argument value to Y to update.',
+                'Y'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getMigrator();
+
+        if ($this->migrator->requireUpdate()) {
+            $this->migrator->update();
+        } else {
+            $output->writeln('Noting to do!');
+        }
+    }
+}

--- a/src/xPDO/Console/Command/ParseSchema.php
+++ b/src/xPDO/Console/Command/ParseSchema.php
@@ -12,7 +12,7 @@ final class ParseSchema extends Command
     protected function configure()
     {
         $this
-            ->setName('parse-schema')
+            ->setFullName('parse-schema')
             ->setDescription('Parse an XML schema and generate xPDO model classes from it')
             ->addArgument(
                 'platform',

--- a/src/xPDO/Console/Command/WriteSchema.php
+++ b/src/xPDO/Console/Command/WriteSchema.php
@@ -11,7 +11,7 @@ final class WriteSchema extends Command
     protected function configure()
     {
         $this
-            ->setName('write-schema')
+            ->setFullName('write-schema')
             ->setDescription("Generate an XML schema from existing database tables.")
             ->addArgument(
                 'platform',

--- a/src/xPDO/Helpers/ConsoleUserInteractionHandler.php
+++ b/src/xPDO/Helpers/ConsoleUserInteractionHandler.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace xPDO\Helpers;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+class ConsoleUserInteractionHandler implements UserInteractionHandler
+{
+    /** @var \Symfony\Component\Console\Input\InputInterface */
+    protected $input;
+
+    /** @var \Symfony\Component\Console\Output\OutputInterface */
+    protected $output;
+
+    /** @var \Symfony\Component\Console\Command\Command; */
+    protected $command;
+
+    /** @var \Symfony\Component\Console\Helper\QuestionHelper */
+    protected $questionHelper;
+
+    /**
+     * CliUserInteractionHandler constructor.
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Command\Command $command
+     */
+    public function setCommandObject(Command $command)
+    {
+        $this->command = $command;
+        // @see: https://symfony.com/doc/3.4/components/console/helpers/questionhelper.html
+        $this->questionHelper = $this->command->getHelper('question');
+    }
+
+    /**
+     * @param string $question
+     * @param bool $default
+     * @return bool
+     */
+    public function promptConfirm(string $question, $default=true)
+    {
+        $confirmationQuestion = new ConfirmationQuestion($question.' <comment>(Y/N)</comment> ', $default);
+        return $this->questionHelper->ask($this->input, $this->output, $confirmationQuestion);
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @return string|mixed ~ user input
+     */
+    public function promptInput(string $question, $default=null)
+    {
+        $questionInput = new Question($question, $default);
+        return $this->questionHelper->ask($this->input, $this->output, $questionInput);
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @param array $options ~ ex: ['Value1, 'Value2',... ] or ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @param string $error_message ~ ex: 'Color %s is invalid.'
+     * @return mixed ~ selected value
+     */
+    public function promptSelectOneOption(string $question, $default=null, $options=[], $error_message='%s is an invalid choice.')
+    {
+        $pretty_options = $this->getPrettyOptions($options);
+
+        /** @var \Symfony\Component\Console\Question\ChoiceQuestion $question */
+        $choiceQuestion = new ChoiceQuestion(
+            $question,
+            $pretty_options['choices'],
+            $default
+        );
+        $choiceQuestion->setErrorMessage($error_message);
+
+        return $pretty_options['map'][$this->questionHelper->ask($this->input, $this->output, $question)];
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default ~ comma sep
+     * @param array $options ~ ex: ['Value1, 'Value2',... ] or ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @param string $error_message ~ ex: 'Color %s is invalid.'
+     * @return array ~ array of selected values
+     */
+    public function promptSelectMultipleOptions(string $question, $default=null, $options=[], $error_message='%s is an invalid choice.')
+    {
+        $pretty_options = $this->getPrettyOptions($options);
+
+        /** @var \Symfony\Component\Console\Question\ChoiceQuestion $question */
+        $choiceQuestion = new ChoiceQuestion(
+            $question,
+            $pretty_options['choices'],
+            $default
+        );
+        $choiceQuestion
+            ->setMultiselect(true)
+            ->setErrorMessage($error_message);
+
+        return $pretty_options['map'][$this->questionHelper->ask($this->input, $this->output, $question)];
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @return string|mixed ~ user input
+     */
+    public function promptHiddenInput(string $question, $default=null)
+    {
+        $questionInput = new Question($question, $default);
+        $questionInput
+            ->setHidden(true)
+            ->setHiddenFallback(false);
+
+        return $this->questionHelper->ask($this->input, $this->output, $questionInput);
+    }
+
+    /**
+     * @param string $string
+     * @param int $type UserInteractionHandler::MASSAGE_STRING, MASSAGE_SUCCESS, MASSAGE_WARNING or MASSAGE_ERROR
+     * @return void
+     */
+    public function tellUser(string $string, int $type)
+    {
+        switch ($type) {
+            case self::MASSAGE_STRING:
+                // no break
+            default:
+                $this->output->writeln($string);
+                break;
+        }
+    }
+
+    /**
+     * @param array $options
+     * @return array
+     */
+    protected function getPrettyOptions($options = [])
+    {
+        $pretty_options = [
+            'choices' => [],
+            'map' => []
+        ];
+        // https://stackoverflow.com/questions/173400/how-to-check-if-php-array-is-associative-or-sequential#173479
+        if (array_keys($options) !== range(0, count($options) - 1)) {
+            foreach ($options as $option => $value) {
+                $pretty_options['choices'][] = $option . '(' . $value . ')';
+                $pretty_options['choices'][$option . '(' . $value . ')'] = $value;
+            }
+
+        } else {
+            foreach ($options as $option) {
+                $pretty_options['choices'][] = $option;
+                $pretty_options['choices'][$option] = $option;
+            }
+        }
+
+        return $pretty_options;
+    }
+}

--- a/src/xPDO/Helpers/EmptyUserInteractionHandler.php
+++ b/src/xPDO/Helpers/EmptyUserInteractionHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace xPDO\Helpers;
+
+class EmptyUserInteractionHandler implements UserInteractionHandler
+{
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * @param string $question
+     * @param bool $default
+     * @return bool
+     */
+    public function promptConfirm(string $question, $default=true)
+    {
+        return $default;
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @return string|mixed ~ user input
+     */
+    public function promptInput(string $question, $default)
+    {
+        return $default;
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @param array $options ~ ex: ['Value1, 'Value2',... ] or ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @param string $error_message ~ ex: 'Color %s is invalid.'
+     * @return mixed ~ selected value
+     */
+    public function promptSelectOneOption(string $question, $default, $options=[], $error_message='%s is an invalid choice.')
+    {
+        return $default;
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default ~ comma sep
+     * @param array $options ~ ex: ['Value1, 'Value2',... ] or ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @param string $error_message ~ ex: 'Color %s is invalid.'
+     * @return array ~ array of selected values
+     */
+    public function promptSelectMultipleOptions(string $question, $default, $options=[], $error_message='%s is an invalid choice.')
+    {
+        return $default;
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @return string|mixed ~ user input
+     */
+    public function promptHiddenInput(string $question, $default)
+    {
+        return $default;
+    }
+
+    /**
+     * @param string $string
+     * @param int $type UserInteractionHandler::MASSAGE_STRING, MASSAGE_SUCCESS, MASSAGE_WARNING or MASSAGE_ERROR
+     * @return void
+     */
+    public function tellUser(string $string, int $type)
+    {
+        echo $string.PHP_EOL;
+    }
+}

--- a/src/xPDO/Helpers/UserInteractionHandler.php
+++ b/src/xPDO/Helpers/UserInteractionHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace xPDO\Helpers;
+
+
+interface UserInteractionHandler
+{
+    const MASSAGE_STRING = 1;
+    const MASSAGE_SUCCESS = 2;
+    const MASSAGE_WARNING = 3;
+    const MASSAGE_ERROR = 4;
+
+    /**
+     * @param string $question
+     * @param bool $default
+     * @return bool
+     */
+    public function promptConfirm(string $question, $default);
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @return string|mixed ~ user input
+     */
+    public function promptInput(string $question, $default);
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @param array $options ~ ex: ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @return mixed ~ selected value
+     */
+    public function promptSelectOneOption(string $question, $default, $options=[]);
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @param array $options ~ ex: ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @return array ~ array of selected values
+     */
+    public function promptSelectMultipleOptions(string $question, $default, $options=[]);
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @return string|mixed ~ user input
+     */
+    public function promptHiddenInput(string $question, $default);
+
+    /**
+     * @param string $string
+     * @param int $type UserInteractionHandler::MASSAGE_STRING, MASSAGE_SUCCESS, MASSAGE_WARNING or MASSAGE_ERROR
+     * @return void
+     */
+    public function tellUser(string $string, int $type);
+
+}

--- a/src/xPDO/Migrations/Migration.php
+++ b/src/xPDO/Migrations/Migration.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace xPDO\Migrations;
+
+use xPDO\xPDO;
+
+/**
+ * Class Migration ~ is the base migration class
+ * @package xPDO\Migrations
+ */
+abstract class Migration
+{
+    /** @var \xPDO\xPDO  */
+    protected $xPDO;
+
+    /** @var  Migrator */
+    protected $migrator;
+
+    /** @var string ~ a description of what this migration will do */
+    protected $description = '';
+
+    /** @var string ~ a version number if you choose */
+    protected $version = '';
+
+    /** @var string ~ master|staging|dev|local */
+    protected $type = 'master';
+
+    /** @var string ~ will be for any seeds to find their related directory */
+    protected $seeds_dir = '';
+
+    /** @var string name of Author of the Migration */
+    protected $author = '';
+
+    /** @var string  */
+    protected $method = 'up';
+
+    /**
+     * Migrations constructor.
+     *
+     * @param $xPDO
+     * @param Migrator $migrator
+     */
+    public function __construct(\xPDO\xPDO &$xPDO, Migrator $migrator)
+    {
+        $this->xPDO = $xPDO;
+        $this->migrator = $migrator;
+
+        $this->assignDescription();
+        $this->assignVersion();
+        $this->assignType();
+        $this->assignSeedsDir();
+    }
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Child class needs to override and implement this
+        $this->xPDO->log(
+            xPDO::LOG_LEVEL_ERROR,
+            get_class($this).'::'.__METHOD__.PHP_EOL.
+            'Did not implement up()'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->method = 'down';
+
+        // Child class needs to override and implement this
+        $this->xPDO->log(
+            xPDO::LOG_LEVEL_ERROR,
+            get_class($this).'::'.__METHOD__.PHP_EOL.
+            'Did not implement down()'
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return (string)$this->description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return (string)$this->version;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string use setSeedsDir
+     */
+    public function getSeedsDir()
+    {
+        return $this->seeds_dir;
+    }
+
+    /**
+     * Method is called on construct, Child class needs to override and implement this
+     */
+    protected function assignDescription()
+    {
+        $this->description = '';
+    }
+
+    /**
+     * Method is called on construct, Child class needs to override and implement this
+     */
+    protected function assignVersion()
+    {
+        $this->version = '';
+    }
+
+    /**
+     * Method is called on construct, Child class can override and implement this
+     */
+    protected function assignType()
+    {
+        $this->type = 'master';
+    }
+
+    /**
+     * Method is called on construct, Child class can override and implement this
+     */
+    protected function assignSeedsDir()
+    {
+        $this->seeds_dir = '';
+    }
+
+}

--- a/src/xPDO/Migrations/MigrationsCreator.php
+++ b/src/xPDO/Migrations/MigrationsCreator.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace xPDO\Migrations;
+
+use xPDO\xPDO;
+
+/**
+ * Class MigrationsCreator ~ will create Migrations
+ * @package xPDO\Migrations
+ */
+class MigrationsCreator
+{
+    /** @var string */
+    protected $description;
+
+    /** @var bool  */
+    protected $log = true;
+
+    /** @var Migrator */
+    protected $migrator;
+
+    /** @var xPDO */
+    protected $xPDO;
+
+    /** @var string  */
+    protected $server_type = 'master';
+
+    /** @var string ~ 1.0.0 the version of the migration file or related project */
+    protected $version = '';
+
+    /**
+     * MigrationsCreator constructor.
+     * @param Migrator $migrator
+     * @param xPDO $xPDO
+     */
+    public function __construct(Migrator $migrator, xPDO $xPDO)
+    {
+        $this->migrator = $migrator;
+        $this->xPDO = $xPDO;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function createBlankMigrationClassFile($name=null)
+    {
+        return $this->writeMigrationClassFile('blank', $name);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServerType()
+    {
+        return $this->server_type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLog()
+    {
+        return $this->log;
+    }
+
+    /**
+     * @param string $description
+     * @return MigrationsCreator
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @param bool $log
+     * @return MigrationsCreator
+     */
+    public function setLog($log)
+    {
+        $this->log = $log;
+        return $this;
+    }
+
+    /**
+     * @param string $server_type
+     * @return MigrationsCreator
+     */
+    public function setServerType($server_type)
+    {
+        $this->server_type = $server_type;
+        return $this;
+    }
+
+    /**
+     * @param string $version
+     * @return MigrationsCreator
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function writeMigrationClassFile($type, $name=null)
+    {
+        $class_name = $this->migrator->getMigrationName($type, $name);
+
+        $migration_template = 'blank.txt';
+        $placeholders = [
+            'classCreateDate' => date('Y/m/d'),
+            'classCreateTime' => date('G:i:s T P'),
+            'className' => $class_name,
+            'classUpInners' => '//@TODO',
+            'classDownInners' => '//@TODO',
+            'description' => $this->getDescription(),
+            'serverType' => $this->getServerType(),
+            'seeds_dir' => $class_name,
+            'version' => $this->getVersion()
+        ];
+
+        $file_contents = '';
+
+        $migration_template = $this->migrator->getMigrationTemplatePath().$migration_template;
+        if (file_exists($migration_template)) {
+            $file_contents = file_get_contents($migration_template);
+        } else {
+            $this->migrator->outError('Migration template file not found: ' . $migration_template);
+        }
+
+        foreach ($placeholders as $name => $value) {
+            $file_contents = str_replace('[[+'.$name.']]', $value, $file_contents);
+        }
+
+        $this->migrator->out($this->migrator->getMigrationPath().$class_name.'.php');
+
+        $write = false;
+        if (file_exists($this->migrator->getMigrationPath().$class_name.'.php')) {
+            $this->migrator->out($this->migrator->getMigrationPath() . $class_name . '.php migration file already exists', true);
+
+        } elseif (is_object($this->xPDO->getObject($this->migrator->getMigrationClassObject(), ['name' => $class_name]))) {
+            $this->migrator->out($class_name . ' migration already has been created in the xpdo_migrations table', true);
+
+        } else {
+            try {
+                $write = file_put_contents($this->migrator->getMigrationPath() . $class_name . '.php', $file_contents);
+                $migration = $this->xPDO->newObject($this->migrator->getMigrationClassObject());
+                if ($migration && $this->isLog()) {
+                    $migration->set('name', $class_name);
+                    $migration->set('type', 'master');
+                    $migration->set('description', '');// @TODO
+                    $migration->set('version', '');
+                    $migration->set('status', 'seed export');
+                    $migration->set('created_at', date('Y-m-d H:i:s'));
+                    $migration->save();
+                }
+            } catch (\Exception $exception) {
+                $this->migrator->out($exception->getMessage(), true);
+            }
+
+            if (!$write) {
+                $this->migrator->out($this->migrator->getMigrationPath() . $class_name . '.php Did not write to file', true);
+                $this->migrator->out('Verify that the folders exists and are writable by PHP', true);
+            }
+        }
+
+        return $write;
+    }
+
+}

--- a/src/xPDO/Migrations/Migrator.php
+++ b/src/xPDO/Migrations/Migrator.php
@@ -1,0 +1,627 @@
+<?php
+
+namespace xPDO\Migrations;
+
+use xPDO\Helpers\UserInteractionHandler;
+use xPDO\Migrations\Model\XPDOMigrations;
+use xPDO\xPDO;
+
+/**
+ * Class Migrator ~ will run migrations
+ * @package xPDO\Migrations
+ */
+class Migrator
+{
+    /** @var string ~ version number of the Migrator/Migrations */
+    private $version = '1.0.0';
+
+    protected $installed_version = null;
+
+    /** @var  xPDO */
+    protected $xPDO;
+
+    /** @var \xPDO\Helpers\UserInteractionHandler */
+    protected $userInteractionHandler;
+
+    /** @var array  */
+    protected $config = [];
+
+    /** @var boolean|array  */
+    protected $xPDOMigrations = false;
+
+    /** @var string date('Y_m_d_His') */
+    protected $seeds_dir = '';
+
+    protected $migration_class_object = 'xPDO\\Migrations\\Model\\XPDOMigrations';
+
+    protected $package = 'xPDO\\Migrations\\Model';
+
+    /**
+     * Stockpile constructor.
+     *
+     * @param xPDO $xPDO
+     * @param UserInteractionHandler $userInteractionHandler
+     * @param array $config
+     */
+    public function __construct(xPDO $xPDO, UserInteractionHandler $userInteractionHandler, $config=[])
+    {
+        $this->xPDO = $xPDO;
+
+        $this->userInteractionHandler = $userInteractionHandler;
+
+        $xpdo_migration_dir = dirname(__FILE__).'/database/migrations/';
+        if (isset($config['xpdo_migration_dir'])) {
+            $xpdo_migration_dir = $config['xpdo_migration_dir'];
+        }
+
+        $xpdo_seeds_dir = dirname(__FILE__).'/database/seeds/';
+        if (isset($config['xpdo_seeds_dir'])) {
+            $xpdo_seeds_dir = $config['xpdo_seeds_dir'];
+        }
+
+        $this->config = [
+            'migration_templates_path' => dirname(__FILE__). '/database/templates/',
+            'migrations_path' => $xpdo_migration_dir,
+            'seeds_path' => $xpdo_seeds_dir,
+            'model_dir' => dirname(__FILE__) . '/',
+            'extras' => [
+                'tagger' => false
+            ]
+        ];
+        $this->config = array_merge($this->config, $config);
+
+        $this->seeds_dir = date('Y_m_d_His');
+
+        $this->xPDO->setPackage($this->package, $this->config['model_dir']);
+    }
+
+    /**
+     * @param string $name
+     * @param string $description
+     * @param string $version
+     * @param string $server_type
+     * @param bool $log
+     *
+     * @return bool
+     */
+    public function createBlankMigrationClassFile($name, $description='', $version='', $server_type='master', $log=true)
+    {
+        $migrationsCreator = new MigrationsCreator($this, $this->xPDO);
+        return $migrationsCreator
+            ->setDescription($description)
+            ->setVersion($version)
+            ->setLog($log)
+            ->setServerType($server_type)
+            ->createBlankMigrationClassFile($name);
+    }
+
+    /**
+     * @return string
+     */
+    public function getMigrationClassObject()
+    {
+        return $this->migration_class_object;
+    }
+    /**
+     * @param $type
+     * @param null $name
+     * @return string
+     */
+    public function getMigrationName($type, $name=null)
+    {
+        $dir_name = 'm'.$this->seeds_dir.'_';
+        if (empty($name)) {
+            $name = ucfirst(strtolower($type));
+        }
+
+        $dir_name .= preg_replace('/[^A-Za-z0-9\_]/', '', str_replace(['/', ' '], '_', $name));
+
+        return $dir_name;
+    }
+
+    /**
+     * @return UserInteractionHandler
+     */
+    public function getUserInteractionHandler()
+    {
+        return $this->userInteractionHandler;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getInstalledVersion()
+    {
+        if (is_null($this->installed_version) ) {
+            if (file_exists(__DIR__ . '/log/version.log')) {
+                $this->installed_version = file_get_contents(__DIR__ . '/log/version.log');
+            } else {
+                $this->installed_version = false;
+            }
+        }
+        return $this->installed_version;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSeedsDir()
+    {
+        return $this->seeds_dir;
+    }
+
+    /**
+     * @param string $seeds_dir ~ local folder
+     *
+     * @return Migrator
+     */
+    public function setSeedsDir($seeds_dir)
+    {
+        $this->seeds_dir = $seeds_dir;
+        return $this;
+    }
+
+    /**
+     * @param null $directory_key
+     * @return string
+     */
+    public function getSeedsPath($directory_key=null)
+    {
+        $seed_path = $this->config['seeds_path'];
+        if (!empty($directory_key)) {
+            $seed_path .= trim($directory_key, '/') . DIRECTORY_SEPARATOR;
+        }
+        return $seed_path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMigrationPath()
+    {
+        return $this->config['migrations_path'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getMigrationTemplatePath()
+    {
+        return $this->config['migration_templates_path'];
+    }
+
+    /**
+     * @param bool $reload
+     * @param string $dir
+     * @param int $count
+     * @param int $id
+     * @param string $name
+     *
+     * @return array ~ array of \XPDOMigrations
+     */
+    public function getxPDOMigrationCollection($reload=false, $dir='ASC', $count=0, $id=0, $name=null)
+    {
+        if (!$this->xPDOMigrations || $reload) {
+            $xPDOMigrations = [];
+
+            /** @var \xPDO\Om\xPDOQuery $query */
+            $query = $this->xPDO->newQuery($this->migration_class_object);
+            if ($id > 0 ) {
+                $query->where(['id' => $id]);
+            } elseif (!empty($name)) {
+                $query->where(['name' => $name]);
+            }
+
+            $query->sortBy('name', $dir);
+            if ($count > 0 ) {
+                $query->limit($count);
+            }
+            $query->prepare();
+            //echo 'SQL: '.$query->toSQL();
+            $migrationCollection = $this->xPDO->getCollection($this->migration_class_object, $query);
+
+            /** @var \xPDO\Migrations\Model\XPDOMigrations $migration */
+            foreach ($migrationCollection as $migration) {
+                $xPDOMigrations[$migration->get('name')] = $migration;
+            }
+            $this->xPDOMigrations = $xPDOMigrations;
+        }
+        return $this->xPDOMigrations;
+    }
+
+    /**
+     * @param string $method
+     * @param bool $prompt
+     */
+    public function install($method='up', $prompt=false)
+    {
+        $migration_name = 'InstallXPDOMigrations';
+        $custom_migration_dir = __DIR__.'/database/migrations/install/';
+
+        $config = $this->config;
+
+        $config['migrations_path'] = $custom_migration_dir;
+
+        if (!empty($seed_root_path)) {
+            $config['seeds_path'] = $seed_root_path;
+        }
+
+        /** @var Migrator $migrator */
+        $migrator = new MigratorInstall($this->xPDO, $this->getUserInteractionHandler(), $config);
+
+        $migrator->runMigration($method, 'master', 0, 0, $migration_name);
+
+        // does the migration directory exist?
+        if (!file_exists($this->getMigrationPath())) {
+            $create = true;
+            if ($prompt) {
+                $response = $this->prompt('Create the following directory for migration files? (y/n) '.PHP_EOL
+                    .$this->getMigrationPath(), 'y');
+                if (strtolower(trim($response)) != 'y') {
+                    $create = false;
+                }
+            }
+            if ($create) {
+                mkdir($this->getMigrationPath(), 0700, true);
+                $this->outSuccess('Created migration directory: '. $this->getMigrationPath());
+            }
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isXPDOMigrationsInstalled()
+    {
+        try {
+            $table = $this->xPDO->getTableName($this->migration_class_object);
+            if ($this->xPDO->query("SELECT 1 FROM {$table} LIMIT 1") === false) {
+                return false;
+            }
+        } catch (\Exception $exception) {
+            // We got an exception == table not found
+            return false;
+        }
+
+        /** @var \xPDO\Om\xPDOQuery $query */
+        $query = $this->xPDO->newQuery($this->migration_class_object);
+        $query->select('id');
+        $query->where([
+            'name' => 'InstallXPDOMigrations',
+            'status' => 'up_complete'
+        ]);
+        $query->sortBy('name');
+
+        $installMigration = $this->xPDO->getObject($this->migration_class_object, $query);
+        if ($installMigration instanceof XPDOMigrations) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $message
+     * @param bool $error
+     */
+    public function out($message, $error=false)
+    {
+        if ($error) {
+            $this->userInteractionHandler->tellUser($message, userInteractionHandler::MASSAGE_ERROR);
+
+        } else {
+            $this->userInteractionHandler->tellUser($message, userInteractionHandler::MASSAGE_STRING);
+        }
+    }
+
+    /**
+     * @param string $message
+     */
+    public function outError($message)
+    {
+        $this->out($message, true);
+    }
+
+    /**
+     * @param string $message
+     */
+    public function outSuccess($message)
+    {
+        $this->userInteractionHandler->tellUser($message, userInteractionHandler::MASSAGE_SUCCESS);
+    }
+
+    /**
+     * @param string $name
+     * @param string $type ~ chunk, plugin, resource, snippet, systemSettings, template, site
+     *
+     * @return bool
+     */
+    public function removeMigrationFile($name, $type)
+    {
+        $class_name = $this->getMigrationName($type, $name);
+
+        $removed = false;
+        $migration_file = $this->getMigrationPath() . $class_name . '.php';
+        if (file_exists($migration_file)) {
+            if (unlink($migration_file)) {
+                $removed = true;
+                $migration = $this->xPDO->getObject($this->migration_class_object, ['name' => $class_name]);
+                if (is_object($migration) && $migration->remove()) {
+                    $this->out($class_name . ' migration has been removed from the xpdo_migrations table');
+
+                }
+            } else {
+                $this->out($class_name . ' migration has not been removed from the xpdo_migrations table', true);
+            }
+
+        } else {
+            $this->out($this->getMigrationPath() . $class_name . '.php migration could not be found to remove', true);
+        }
+
+        return $removed;
+    }
+
+    /**
+     * @return bool
+     */
+    public function requireUpdate()
+    {
+        $upgrade = false;
+
+        $db_version = $this->getInstalledVersion();
+        if ( $this->isXPDOMigrationsInstalled() && ( !$db_version || version_compare($this->getVersion(), $db_version)) ) {
+            $upgrade = true;
+        }
+
+        return $upgrade;
+    }
+
+    /**
+     * @param bool $save
+     * @return array ~ ['Migration Name' => xPDOMigrations, ...]
+     */
+    public function retrieveMigrationFiles($save=true)
+    {
+        // 1. Get all migrations currently in DB:
+        $migrationCollection = $this->xPDO->getCollection($this->migration_class_object);
+
+        $xPDOMigrations = [];
+
+        /** @var xPDOMigrations $migration */
+        foreach ($migrationCollection as $migration) {
+            $xPDOMigrations[$migration->get('name')] = $migration;
+        }
+
+        $migration_dir = $this->getMigrationPath();
+        $this->out('Searching '.$migration_dir);
+
+        /** @var \DirectoryIterator $file */
+        foreach (new \DirectoryIterator($this->getMigrationPath()) as $file) {
+            if ($file->isFile() && $file->getExtension() == 'php') {
+
+                $name = $file->getBasename('.php');
+                // @TODO query DB! and test this method
+                if (!isset($xPDOMigrations[$name])) {
+                    $this->out('Create new '.$name);
+                    /** @var \xPDO\Migrations\Migration $migrationProcessClass */
+                    $migrationProcessClass = $this->loadMigrationClass($name, $this);
+
+                    /** @var xPDOMigrations $migration */
+                    $migration = $this->xPDO->newObject($this->migration_class_object);
+                    $migration->set('name', $name);
+                    $migration->set('status', 'ready');
+                    if ($migrationProcessClass instanceof Migration) {
+                        $migration->set('description', $migrationProcessClass->getDescription());
+                        $migration->set('version', $migrationProcessClass->getVersion());
+                        $migration->set('author', $migrationProcessClass->getAuthor());
+                    }
+
+                    if ($save && !$migration->save()) {
+                        exit();
+                    };
+
+                    $xPDOMigrations[$name] = $migration;
+                }
+            }
+        }
+
+        return $xPDOMigrations;
+    }
+
+    /**
+     * @param string $method
+     * @param string $type
+     * @param int $count
+     * @param int $id
+     * @param string $migration_name
+     */
+    public function runMigration($method='up', $type='master', $count=0, $id=0, $migration_name=null)
+    {
+        $dir = 'ASC';
+        if ($method == 'down') {
+            $dir = 'DESC';
+        } else {
+            $count = 0;
+        }
+        // 1. Get all migrations currently in DB:
+        $xPDOMigrations = [];
+        if ($migrations_installed = $this->isXPDOMigrationsInstalled()) {
+            $xPDOMigrations = $this->getxPDOMigrationCollection(false, $dir, $count, $id, $migration_name);
+        }
+
+        // 2. Load migration files:
+        if ($method == 'up') {
+            $xPDOMigrations = $this->retrieveMigrationFiles($migrations_installed);
+            if ($migrations_installed) {
+                // this is needed just to insure that the order is correct and any new files
+                $xPDOMigrations = $this->getxPDOMigrationCollection(true, $dir, $count, $id, $migration_name);
+            }
+        }
+
+        // 3. now run migration if proper
+        /** @var xPDOMigrations $migration */
+        foreach ($xPDOMigrations as $name => $migration) {
+            if (($id > 0 && $migration->get('id') != $id) || (!empty($migration_name) && $name != $migration_name)) {
+                continue;
+            }
+            /** @var string $name */
+            $name = $migration->get('name');
+
+            /** @var string $status ~ ready|up_complete|down_complete*/
+            $status = $migration->get('status');
+
+            /** @var string $server_type */
+            $server_type = $migration->get('type');
+
+            if ( ($server_type != $type) || ($method == 'up' && $status == 'up_complete') || ($method == 'down' && $status != 'up_complete') ) {
+                continue;
+            }
+
+            /** @var Migrator $migrator */
+            //$migrator = new Migrator($this->xPDO, $this->getUserInteractionHandler(), $this->config);
+
+            /** @var Migration $migrationProcessClass */
+            $migrationProcessClass = $this->loadMigrationClass($name, $this);
+
+            if ($migrationProcessClass instanceof Migration) {
+                $this->out('Load Class: '.$name.' M: '.$method);
+                if ($method == 'up') {
+                    $migrationProcessClass->up();
+                    $this->out('Run up: '.$name);
+                    $migration->set('status', 'up_complete');
+                    $migration->set('processed_at', date('Y-m-d H:i:s'));
+                    $migration->save();
+
+                } elseif ($method == 'down') {
+                    $migrationProcessClass->down();
+                    $migration->set('status', 'down_complete');
+                    $migration->set('processed_at', date('Y-m-d H:i:s'));
+                    $migration->save();
+
+                } else {
+                    $this->outError('Invalid method: ' . $method);
+                }
+            } else {
+                $this->outError('Invalid migration: ' . $name);
+            }
+        }
+    }
+
+    /**
+     * @param string $method
+     */
+    public function update($method='up')
+    {
+        $config = $this->config;
+        $config['migrations_path'] = __DIR__.'/database/migrations/updates/';
+
+        $migrator = new MigratorInstall($this->xPDO, $this->getUserInteractionHandler(), $config);
+
+        $migrator->runMigration($method);
+    }
+
+    /**
+     * @param string $name
+     * @param Migrator $migrator
+     *
+     * @return bool|Migration
+     */
+    protected function loadMigrationClass($name, Migrator $migrator)
+    {
+        $migrationProcessClass = false;
+
+        $file = $migrator->getMigrationPath().$name.'.php';
+        if (file_exists($file)) {
+            require_once $file;
+
+            if(class_exists($name)) {
+                /** @var Migration $migrationProcessClass */
+                $migrationProcessClass = new $name($this->xPDO, $migrator);
+            }
+        }
+
+        return $migrationProcessClass;
+    }
+
+    /**
+     * @param mixed|array $data
+     * @param int $tabs
+     *
+     * @return string
+     */
+    protected function prettyVarExport($data, $tabs=1)
+    {
+        $spacing = str_repeat(' ', 4*$tabs);
+
+        $string = '';
+        $parts = preg_split('/\R/', var_export($data, true));
+        foreach ($parts as $k => $part) {
+            if ($k > 0) {
+                $string .= $spacing;
+            }
+            $string .= $part.PHP_EOL;
+        }
+
+        return trim($string);
+    }
+
+    /**
+     * @param string $question
+     * @param string $default
+     *
+     * @return mixed
+     */
+    protected function prompt($question, $default='')
+    {
+        return $this->userInteractionHandler->promptInput($question, $default);
+    }
+
+    /**
+     * @param string $question
+     * @param bool $default
+     * @return bool
+     */
+    protected function promptConfirm($question, $default=true)
+    {
+        return $this->userInteractionHandler->promptConfirm($question, $default);
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @param array $options ~ ex: ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @return mixed ~ selected value
+     */
+    protected function promptSelectOneOption($question, $default, $options=[])
+    {
+        return $this->userInteractionHandler->promptSelectOneOption($question, $default, $options);
+    }
+
+    /**
+     * @param string $question
+     * @param string|mixed $default
+     * @param array $options ~ ex: ['Option1' => 'value', 'Option2' => 'value2', ...]
+     * @return array ~ array of selected values
+     */
+    protected function promptSelectMultipleOptions($question, $default, $options=[])
+    {
+        return $this->userInteractionHandler->promptSelectMultipleOptions($question, $default, $options);
+    }
+
+    /**
+     * @param string $version ~ 1.0.0
+     */
+    protected function setDBVersion($version)
+    {
+        file_put_contents(__DIR__.'/log/version.log', $version);
+
+    }
+}

--- a/src/xPDO/Migrations/MigratorInstall.php
+++ b/src/xPDO/Migrations/MigratorInstall.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace xPDO\Migrations;
+
+/**
+ * Class Migrator ~ will run migrations
+ * @package xPDO\Migrations
+ */
+class MigratorInstall extends Migrator
+{
+    /**
+     * @param string $version ~ 1.0.0
+     */
+    public function setDBVersion($version)
+    {
+        file_put_contents(__DIR__.'/log/version.log', $version);
+    }
+}

--- a/src/xPDO/Migrations/Model/XPDOMigrations.php
+++ b/src/xPDO/Migrations/Model/XPDOMigrations.php
@@ -1,0 +1,22 @@
+<?php
+namespace xPDO\Migrations\Model;
+
+use xPDO\xPDO;
+
+/**
+ * Class XPDOMigrations
+ *
+ * @property string $name
+ * @property string $version
+ * @property string $type
+ * @property string $description
+ * @property string $status
+ * @property string $author
+ * @property string $created_at
+ * @property string $processed_at
+ *
+ * @package xPDO\Migrations\Model
+ */
+class XPDOMigrations extends \xPDO\Om\xPDOSimpleObject
+{
+}

--- a/src/xPDO/Migrations/Model/metadata.mysql.php
+++ b/src/xPDO/Migrations/Model/metadata.mysql.php
@@ -1,0 +1,13 @@
+<?php
+$xpdo_meta_map = array (
+    'version' => '3.0',
+    'namespace' => 'xPDO\\Migrations\\Model',
+    'namespacePrefix' => 'PSR4',
+    'class_map' => 
+    array (
+        'xPDO\\Om\\xPDOSimpleObject' => 
+        array (
+            0 => 'xPDO\\Migrations\\Model\\XPDOMigrations',
+        ),
+    ),
+);

--- a/src/xPDO/Migrations/Model/mysql/XPDOMigrations.php
+++ b/src/xPDO/Migrations/Model/mysql/XPDOMigrations.php
@@ -1,0 +1,85 @@
+<?php
+namespace xPDO\Migrations\Model\mysql;
+
+use xPDO\xPDO;
+
+class XPDOMigrations extends \xPDO\Migrations\Model\XPDOMigrations
+{
+
+    public static $metaMap = array (
+        'package' => 'xPDO\\Migrations\\Model',
+        'version' => '3.0',
+        'table' => 'xpdo_migrations',
+        'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'fields' => 
+        array (
+            'name' => NULL,
+            'version' => NULL,
+            'type' => 'master',
+            'description' => NULL,
+            'status' => 'ready',
+            'author' => NULL,
+            'created_at' => 'CURRENT_TIMESTAMP',
+            'processed_at' => NULL,
+        ),
+        'fieldMeta' => 
+        array (
+            'name' => 
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '255',
+                'phptype' => 'string',
+                'null' => false,
+            ),
+            'version' => 
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '32',
+                'phptype' => 'string',
+                'null' => true,
+            ),
+            'type' => 
+            array (
+                'dbtype' => 'set',
+                'precision' => '\'master\',\'stagging\',\'dev\',\'local\'',
+                'phptype' => 'string',
+                'null' => false,
+                'default' => 'master',
+            ),
+            'description' => 
+            array (
+                'dbtype' => 'text',
+                'phptype' => 'string',
+                'null' => true,
+            ),
+            'status' => 
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '16',
+                'phptype' => 'string',
+                'null' => false,
+                'default' => 'ready',
+            ),
+            'author' => 
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '255',
+                'phptype' => 'string',
+                'null' => true,
+            ),
+            'created_at' => 
+            array (
+                'dbtype' => 'timestamp',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 'CURRENT_TIMESTAMP',
+            ),
+            'processed_at' => 
+            array (
+                'dbtype' => 'timestamp',
+                'phptype' => 'timestamp',
+                'null' => true,
+            ),
+        ),
+    );
+}

--- a/src/xPDO/Migrations/Model/schema/migrations.mysql.schema.xml
+++ b/src/xPDO/Migrations/Model/schema/migrations.mysql.schema.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model package="xPDO\Migrations\Model" baseClass="xPDO\Om\xPDOObject" platform="mysql" defaultEngine="MyISAM" version="3.0">
+	<object class="XPDOMigrations" table="xpdo_migrations" extends="xPDO\Om\xPDOSimpleObject">
+		<field key="name" dbtype="varchar" precision="255" phptype="string" null="false" />
+		<field key="version" dbtype="varchar" precision="32" phptype="string" null="true" />
+		<field key="type" dbtype="set" precision="'master','stagging','dev','local'" phptype="string" null="false" default="master" />
+		<field key="description" dbtype="text" phptype="string" null="true" />
+		<field key="status" dbtype="varchar" precision="16" phptype="string" null="false" default="ready" />
+		<field key="author" dbtype="varchar" precision="255" phptype="string" null="true" />
+		<field key="created_at" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" />
+		<field key="processed_at" dbtype="timestamp" phptype="timestamp" null="true" />
+	</object>
+</model>

--- a/src/xPDO/Migrations/database/migrations/install/InstallXPDOMigrations.php
+++ b/src/xPDO/Migrations/database/migrations/install/InstallXPDOMigrations.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Ideally, this file should never be changed and no additional install scripts should be created
+ * But on any DB/schema update a new update migration should be created relating to the new version like:
+ * v001_000_001_Update that migration would then update the DB schema from the first release. So every installation runs
+ * starts from install and then runs every update step.
+ * @TODO issue: If say column help is added to the xPDO schema modal and for new installs it would run the install to
+ *  createObjectContainer() and it would also add the column help and then the update migration would run in both situations
+ *  and attempt to add the help column. For new installs this would create an error, maybe each update has to check if
+ *  change has been made before updating?
+ */
+
+use xPDO\Migrations\Migration;
+
+class InstallXPDOMigrations extends Migration
+{
+    /** @var \xPDO\Migrations\MigratorInstall */
+    protected $migrator;
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // install DB table:
+        $manager = $this->xPDO->getManager();
+
+        // the class table object name
+        $table_class = $this->migrator->getMigrationClassObject();
+        if ($manager->createObjectContainer($table_class)) {
+            $this->migrator->out($table_class.' table class has been created');
+            $this->migrator->setDBVersion('1.0.0');
+
+        } else {
+            $this->migrator->out($table_class.' table class was not created', true);
+        }
+
+        $this->xPDO->getCacheManager()->refresh();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // remove DB Table:
+        $manager = $this->xPDO->getManager();
+
+        // the class table object name
+        $table_class = $this->migrator->getMigrationClassObject();
+        if ($manager->removeObjectContainer($table_class)) {
+            $this->migrator->out($table_class.' table class has been dropped');
+
+        } else {
+            $this->migrator->out($table_class.' table class was not dropped', true);
+        }
+
+        $this->xPDO->getCacheManager()->refresh();
+    }
+
+    /**
+     * Method is called on construct, please fill me in
+     */
+    protected function assignDescription()
+    {
+        $this->description = 'Install of Migrations';
+    }
+
+    /**
+     * Method is called on construct, please fill me in
+     */
+    protected function assignVersion()
+    {
+        $this->version = $this->migrator->getVersion();
+    }
+
+    /**
+     * Method is called on construct, can change to only run this migration for those types
+     */
+    protected function assignType()
+    {
+        $this->type = 'master';
+    }
+
+    /**
+     * Method is called on construct, Child class can override and implement this
+     */
+    protected function assignSeedsDir()
+    {
+        $this->seeds_dir = '2018_07_16_010101';
+    }
+}

--- a/src/xPDO/Migrations/database/templates/blank.txt
+++ b/src/xPDO/Migrations/database/templates/blank.txt
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Auto Generated from xPDO Migrations
+ * Date: [[+classCreateDate]] at [[+classCreateTime]]
+ */
+
+use \xPDO\Migrations\Migration;
+
+class [[+className]] extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        /** @var \xPDO\xPDO is now available */
+        $this->xPDO;
+        [[+classUpInners]]
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        [[+classDownInners]]
+    }
+
+    /**
+     * Method is called on construct, please fill me in
+     */
+    protected function assignDescription()
+    {
+        $this->description = '[[+description]]';
+    }
+
+    /**
+     * Method is called on construct, please fill me in
+     */
+    protected function assignVersion()
+    {
+        $this->version = '[[+version]]';
+    }
+
+    /**
+     * Method is called on construct, can change to only run this migration for those types
+     */
+    protected function assignType()
+    {
+        $this->type = '[[+serverType]]';
+    }
+
+    /**
+     * Method is called on construct, Child class can override and implement this
+     */
+    protected function assignSeedsDir()
+    {
+        $this->seeds_dir = '[[+seeds_dir]]';
+    }
+}


### PR DESCRIPTION
Simple migrations for xPDO.

What are Migrations?
Think of migrations as creating instructions for data to be imported or modified. Migrations can be used like version control for your database, allowing your team to easily modify and share the changes across environments.

Tests will be next commit