### PR TITLE
Select columns ignored by xPDOCacheManager

### DIFF
--- a/src/xPDO/Cache/xPDOCacheManager.php
+++ b/src/xPDO/Cache/xPDOCacheManager.php
@@ -22,6 +22,9 @@ class xPDOCacheManager {
     const CACHE_JSON = 1;
     const CACHE_SERIALIZE = 2;
     const CACHE_DIR = 'objects/';
+    const CACHE_RAW_VALUES = true;
+    const CACHE_EXCLUDE_LAZY = false;
+    const CACHE_INCLUDE_RELATED = false;
     const LOG_DIR = 'logs/';
 
     /** @var xPDO */
@@ -593,7 +596,8 @@ class xPDOCacheManager {
         if (is_object($obj) && $obj instanceof \xPDO\Om\xPDOObject) {
             $className= $obj->_class;
             $source= "\${$objName}= \${$objRef}->newObject('{$className}');\n";
-            $source .= "\${$objName}->fromArray(" . var_export($obj->toArray('', true), true) . ", '', true, true);\n";
+            $source .= "\${$objName}->fromArray(" . var_export($obj->toArray('', $this->getOption(xPDO::OPT_CACHE_RAW_VALUES, $options, xPDOCacheManager::CACHE_RAW_VALUES), $this->getOption(xPDO::OPT_CACHE_EXCLUDE_LAZY, $options, xPDOCacheManager::CACHE_EXCLUDE_LAZY), $this->getOption(xPDO::OPT_CACHE_INCLUDE_RELATED, $options, xPDOCacheManager::CACHE_INCLUDE_RELATED)
+                ), true) . ", '', true, true);\n";
             if ($generateObjVars && $objectVars= get_object_vars($obj)) {
                 foreach ($objectVars as $vk => $vv) {
                     if ($vk === 'modx') {
@@ -630,7 +634,8 @@ class xPDOCacheManager {
         if ($cache = $this->getCacheProvider($this->getOption(xPDO::OPT_CACHE_KEY, $options))) {
             $value= null;
             if (is_object($var) && $var instanceof \xPDO\Om\xPDOObject) {
-                $value= $var->toArray('', true);
+                $value= $var->toArray('', $this->getOption(xPDO::OPT_CACHE_RAW_VALUES, $options, xPDOCacheManager::CACHE_RAW_VALUES), $this->getOption(xPDO::OPT_CACHE_EXCLUDE_LAZY, $options, xPDOCacheManager::CACHE_EXCLUDE_LAZY), $this->getOption(xPDO::OPT_CACHE_INCLUDE_RELATED, $options, xPDOCacheManager::CACHE_INCLUDE_RELATED)
+                );
             } else {
                 $value= $var;
             }
@@ -654,7 +659,8 @@ class xPDOCacheManager {
         if ($cache = $this->getCacheProvider($this->getOption(xPDO::OPT_CACHE_KEY, $options), $options)) {
             $value= null;
             if (is_object($var) && $var instanceof \xPDO\Om\xPDOObject) {
-                $value= $var->toArray('', true);
+                $value= $var->toArray('', $this->getOption(xPDO::OPT_CACHE_RAW_VALUES, $options, xPDOCacheManager::CACHE_RAW_VALUES), $this->getOption(xPDO::OPT_CACHE_EXCLUDE_LAZY, $options, xPDOCacheManager::CACHE_EXCLUDE_LAZY), $this->getOption(xPDO::OPT_CACHE_INCLUDE_RELATED, $options, xPDOCacheManager::CACHE_INCLUDE_RELATED)
+                );
             } else {
                 $value= $var;
             }
@@ -678,7 +684,8 @@ class xPDOCacheManager {
         if ($cache = $this->getCacheProvider($this->getOption(xPDO::OPT_CACHE_KEY, $options), $options)) {
             $value= null;
             if (is_object($var) && $var instanceof \xPDO\Om\xPDOObject) {
-                $value= $var->toArray('', true);
+                $value= $var->toArray('', $this->getOption(xPDO::OPT_CACHE_RAW_VALUES, $options, xPDOCacheManager::CACHE_RAW_VALUES), $this->getOption(xPDO::OPT_CACHE_EXCLUDE_LAZY, $options, xPDOCacheManager::CACHE_EXCLUDE_LAZY), $this->getOption(xPDO::OPT_CACHE_INCLUDE_RELATED, $options, xPDOCacheManager::CACHE_INCLUDE_RELATED)
+                );
             } else {
                 $value= $var;
             }

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -78,6 +78,9 @@ class xPDO {
     const OPT_CACHE_PREFIX = 'cache_prefix';
     const OPT_CACHE_ATTEMPTS = 'cache_attempts';
     const OPT_CACHE_ATTEMPT_DELAY = 'cache_attempt_delay';
+    const OPT_CACHE_RAW_VALUES = 'cache_raw_values';
+    const OPT_CACHE_EXCLUDE_LAZY = 'cache_exclude_lazy';
+    const OPT_CACHE_INCLUDE_RELATED = 'cache_include_related';
     const OPT_CALLBACK_ON_REMOVE = 'callback_on_remove';
     const OPT_CALLBACK_ON_SAVE = 'callback_on_save';
     const OPT_CONNECTIONS = 'connections';
@@ -2357,7 +2360,10 @@ class xPDO {
                             xPDO::OPT_CACHE_HANDLER => $this->getOption(xPDO::OPT_CACHE_DB_HANDLER, $options, $this->getOption(xPDO::OPT_CACHE_HANDLER, $options, 'xPDO\\Cache\\xPDOFileCache')),
                             xPDO::OPT_CACHE_FORMAT => (integer) $this->getOption('cache_db_format', $options, $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, Cache\xPDOCacheManager::CACHE_PHP)),
                             xPDO::OPT_CACHE_EXPIRES => (integer) $this->getOption(xPDO::OPT_CACHE_DB_EXPIRES, null, $this->getOption(xPDO::OPT_CACHE_EXPIRES, null, 0)),
-                            xPDO::OPT_CACHE_PREFIX => $this->getOption('cache_db_prefix', $options, Cache\xPDOCacheManager::CACHE_DIR)
+                            xPDO::OPT_CACHE_PREFIX => $this->getOption('cache_db_prefix', $options, Cache\xPDOCacheManager::CACHE_DIR),
+                            xPDO::OPT_CACHE_RAW_VALUES => $this->getOption(xPDO::OPT_CACHE_RAW_VALUES, $options, Cache\xPDOCacheManager::CACHE_RAW_VALUES),
+                            xPDO::OPT_CACHE_EXCLUDE_LAZY => $this->getOption(xPDO::OPT_CACHE_EXCLUDE_LAZY, $options, Cache\xPDOCacheManager::CACHE_EXCLUDE_LAZY),
+                            xPDO::OPT_CACHE_INCLUDE_RELATED => $this->getOption(xPDO::OPT_CACHE_INCLUDE_RELATED, $options, Cache\xPDOCacheManager::CACHE_INCLUDE_RELATED),
                         ));
                         $result= $this->cacheManager->set($sig, $object, $lifetime, $cacheOptions);
                         if ($result && $object instanceof Om\xPDOObject) {


### PR DESCRIPTION
Currently a query that specifies columns to return will still return all when using built in caching.

Example:
```
$query = $this->xpdo->newQuery($this->class);

$query->select($this->xpdo->getSelectColumns($this->class, $this->class, '', array('UserName', 'UserPassword'), true));
//or
$query->select($this->xpdo->getSelectColumns($this->class, $this->class, '', array('id', 'UserName', 'UserPassword'), false));

$output = $this->xpdo->getObject($this->class, $query, true);

if ($output) {
    print_r($output->toArray('', false, true), true);
}
```
The `$output` array will still include all fields.

This is because the methods that write/edit cached files use `toArray()` with default settings so `excludeLazy` is always set to false so all columns are included regardless. Explained here: https://docs.modx.com/xpdo/2.x/class-reference/xpdoquery/xpdoquery.select

This PR adds optional settings which allow you to pass options to `toArray()` like:
```
$this->xpdo->setOption(\xPDO\xPDO::OPT_CACHE_EXCLUDE_LAZY,true);
```
or
```
$xpdo = \xPDO\xPDO::getInstance('foo',[
    xPDO::OPT_CACHE_EXCLUDE_LAZY => true,
    xPDO::OPT_CONNECTIONS => array(
       array()
       ),
    ),
]);
return $xpdo;
```