### PR TITLE
Allow non-array values to be properly written when parsing schemas

### DIFF
--- a/src/xPDO/Om/xPDOGenerator.php
+++ b/src/xPDO/Om/xPDOGenerator.php
@@ -129,6 +129,9 @@ abstract class xPDOGenerator {
                 $output[] = str_repeat('    ', $indentLevel + 1) . str_repeat('    ', $spaces / 2) . substr($line, ($spaces ? $spaces + 1 : 0));
             }
         }
+        else {
+            $output[] = var_export($var, true);
+        }
         return implode("\n", $output);
     }
 


### PR DESCRIPTION
Imagine a model class like this:

```
class Account extends WhateverBaseObject
{
    public const SUSPEND_PAYMENTOVERDUE = 'payment_overdue';
    public const SUSPEND_REQUESTED = 'requested';
    public const SUSPEND_TRIALEND = 'trial_end';
    public const SUSPEND_NOPAYMENTMETHOD = 'no_payment_method';

    // ...
}
```

When parsing the schema with a command like this:

```
vendor/bin/xpdo parse-schema mysql package.mysql.schema.xml src/ -v --update=1 --psr4=Package
```

... the xPDOGenerator parses constants and writes them into the platform specific class.

However due to a bug in `varExport`, the value is lost, leading to the mysql class looking like this:

```
class Account extends \Package\Account
{
    const SUSPEND_PAYMENTOVERDUE = ;
    const SUSPEND_REQUESTED = ;
    const SUSPEND_TRIALEND = ;
    const SUSPEND_NOPAYMENTMETHOD = ;
```

which is invalid PHP and causes a hard fatal error. 

With this patch, non-array values are preserved in constants, leading to functional code:

```
class Account extends \Package\Account
{
    const SUSPEND_PAYMENTOVERDUE = 'payment_overdue';
    const SUSPEND_REQUESTED = 'requested';
    const SUSPEND_TRIALEND = 'trial_end';
    const SUSPEND_NOPAYMENTMETHOD = 'no_payment_method';
```

Personally I think it would be better if the constants weren't copied into platform classes at all. They're inherited, so why write them again? 

I'm also using some constants that refer to other constants (e.g. `public const ENCRYPTION = EncryptionHelper::ENCRYPTION_SOME_TYPE`), which due to this platform code is ending up with the _value_ of that second constant, rather than the constant itself. Those values wont change, so that's fine for now, but it seems like a great source for potential bugs.

I've looked at defining a custom platform template that skips it, but that doesn't seem possible to pass in at the moment. 