### PR TITLE
Fix deprecation warnings for PHP 7.4 compatibility

### DIFF
--- a/xpdo/cache/xpdocachemanager.class.php
+++ b/xpdo/cache/xpdocachemanager.class.php
@@ -163,7 +163,7 @@ class xPDOCacheManager {
                     break;
                 }
                 if ($cachePath) {
-                    if ($cachePath{strlen($cachePath) - 1} != '/') $cachePath .= '/';
+                    if ($cachePath[strlen($cachePath) - 1] != '/') $cachePath .= '/';
                     $cachePath .= '.xpdo-cache';
                 }
             }
@@ -177,7 +177,7 @@ class xPDOCacheManager {
             $perms = $this->getOption('new_folder_permissions', null, $this->getFolderPermissions());
             if (is_string($perms)) $perms = octdec($perms);
             if (@ $this->writeTree($cachePath, $perms)) {
-                if ($cachePath{strlen($cachePath) - 1} != '/') $cachePath .= '/';
+                if ($cachePath[strlen($cachePath) - 1] != '/') $cachePath .= '/';
                 if (!is_writeable($cachePath)) {
                     @ chmod($cachePath, $perms);
                 }
@@ -331,7 +331,7 @@ class xPDOCacheManager {
             $mode = $this->getOption('new_folder_permissions', $options, $this->getFolderPermissions());
             if (is_string($mode)) $mode = octdec($mode);
             $dirname= strtr(trim($dirname), '\\', '/');
-            if ($dirname{strlen($dirname) - 1} == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
+            if ($dirname[strlen($dirname) - 1] == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
             if (is_dir($dirname) || (is_writable(dirname($dirname)) && @mkdir($dirname, $mode))) {
                 $written= true;
             } elseif (!$this->writeTree(dirname($dirname), $options)) {
@@ -404,8 +404,8 @@ class xPDOCacheManager {
         $copied= false;
         $source= strtr($source, '\\', '/');
         $target= strtr($target, '\\', '/');
-        if ($source{strlen($source) - 1} == '/') $source = substr($source, 0, strlen($source) - 1);
-        if ($target{strlen($target) - 1} == '/') $target = substr($target, 0, strlen($target) - 1);
+        if ($source[strlen($source) - 1] == '/') $source = substr($source, 0, strlen($source) - 1);
+        if ($target[strlen($target) - 1] == '/') $target = substr($target, 0, strlen($target) - 1);
         if (is_dir($source . '/')) {
             if (!is_array($options)) $options = is_scalar($options) && !is_bool($options) ? array('new_folder_permissions' => $options) : array();
             if (func_num_args() === 4) $options['new_file_permissions'] = func_get_arg(3);

--- a/xpdo/changelog.txt
+++ b/xpdo/changelog.txt
@@ -1,5 +1,7 @@
 This file shows the changes in this release of xPDO.
 
+- Fix PHP 7.4 deprecation warnings for array and string offset access with curly braces
+
 xPDO 2.7.0-pl (May 2, 2018)
 ====================================
 - Fix xPDOIterator failure when fetch returns null due to object hydration


### PR DESCRIPTION
This resolves warnings in xPDOCacheManager because array and string offset access syntax with curly braces is deprecated in PHP 7.4