### PR TITLE
Improve PSR-4 support by allowing namespace prefixes to be removed from package name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ This file shows the changes in this release of xPDO.
 
 xPDO 3.0.0 (TBD)
 ====================================
+- Improve PSR-4 support by allowing namespace prefixes to be removed from package name
 - Fix PHP 7.4 deprecation warnings for array and string offset access with curly braces
 - Add xPDO->getAlias() method to get a class name without the namespace
 - Quote default column values for MySQL

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -439,12 +439,12 @@ class xPDO {
      * @param string|null $prefix Provide a string to define a package-specific table_prefix.
      * @return bool
      */
-    public function setPackage($pkg= '', $path= '', $prefix= null) {
+    public function setPackage($pkg= '', $path= '', $prefix= null, $namespacePrefix= null) {
         if (empty($path) && isset($this->packages[$pkg])) {
             $path= $this->packages[$pkg]['path'];
             $prefix= !is_string($prefix) && array_key_exists('prefix', $this->packages[$pkg]) ? $this->packages[$pkg]['prefix'] : $prefix;
         }
-        $set= $this->addPackage($pkg, $path, $prefix);
+        $set= $this->addPackage($pkg, $path, $prefix, $namespacePrefix);
         $this->package= $set == true ? $pkg : $this->package;
         if ($set && is_string($prefix)) $this->config[xPDO::OPT_TABLE_PREFIX]= $prefix;
         return $set;
@@ -458,7 +458,7 @@ class xPDO {
      * @param string|null $prefix Provide a string to define a package-specific table_prefix.
      * @return bool
      */
-    public function addPackage($pkg= '', $path= '', $prefix= null) {
+    public function addPackage($pkg= '', $path= '', $prefix= null, $namespacePrefix= null) {
         $added= false;
         if (is_string($pkg) && !empty($pkg)) {
             if (!is_string($path) || empty($path)) {
@@ -471,7 +471,7 @@ class xPDO {
                 $prefix= !is_string($prefix) ? $this->config[xPDO::OPT_TABLE_PREFIX] : $prefix;
                 if (!array_key_exists($pkg, $this->packages) || $this->packages[$pkg]['path'] !== $path || $this->packages[$pkg]['prefix'] !== $prefix) {
                     $this->packages[$pkg]= array('path' => $path, 'prefix' => $prefix);
-                    $this->setPackageMeta($pkg, $path);
+                    $this->setPackageMeta($pkg, $path, $namespacePrefix);
                 }
                 $added= true;
             }
@@ -488,10 +488,14 @@ class xPDO {
      * @param string $path The root path for looking up classes in this package.
      * @return bool
      */
-    public function setPackageMeta($pkg, $path = '') {
+    public function setPackageMeta($pkg, $path = '', $namespacePrefix= null) {
         $set = false;
         if (is_string($pkg) && !empty($pkg)) {
             $pkgPath = str_replace(array('.', '\\'), array('/', '/'), $pkg);
+            $namespacePrefixPath = !empty($namespacePrefix) ? str_replace('\\', '/', $namespacePrefix) : '';
+            if (!empty($namespacePrefixPath) && strpos($pkgPath, $namespacePrefixPath) === 0) {
+                $pkgPath = substr($pkgPath, strlen($namespacePrefixPath));
+            }
             $mapFile = $path . $pkgPath . '/metadata.' . $this->config['dbtype'] . '.php';
             if (file_exists($mapFile)) {
                 $xpdo_meta_map = array();

--- a/test/xPDO/Test/PSR4/TestCase.php
+++ b/test/xPDO/Test/PSR4/TestCase.php
@@ -16,6 +16,6 @@ class TestCase extends \xPDO\TestCase
     protected function setUp()
     {
         $this->xpdo = self::getInstance(true);
-        $this->xpdo->setPackage('Sample', self::$properties['xpdo_test_path'] . 'model/PSR4/');
+        $this->xpdo->setPackage('xPDO\Test\Sample', self::$properties['xpdo_test_path'] . 'model/PSR4/', null, 'xPDO\\Test\\');
     }
 }


### PR DESCRIPTION
Previously, in order to use PSR-4, you could not include the entire namespace in the package name when using `setPackage()` or `addPackage()` with a namespace prefix. This change will allow you to specify the entire namespace within the package name and pass the namespace prefix into the method calls so they know not to append the entire namespace to the path when searching for the metadata file.