### PR TITLE
Fix xPDOFileCache->delete() when a directory with same cache key exists

### DIFF
--- a/xpdo/cache/xpdocachemanager.class.php
+++ b/xpdo/cache/xpdocachemanager.class.php
@@ -1012,17 +1012,18 @@ class xPDOFileCache extends xPDOCache {
 
     public function delete($key, $options= array()) {
         $deleted= false;
-        $cacheKey= $this->getCacheKey($key, array_merge($options, array('cache_ext' => '')));
-        if (file_exists($cacheKey) && is_dir($cacheKey)) {
-            $results = $this->xpdo->cacheManager->deleteTree($cacheKey, array_merge(array('deleteTop' => false, 'skipDirs' => false, 'extensions' => array('.cache.php')), $options));
-            if ($results !== false) {
-                $deleted = true;
+        if ($this->getOption('multiple_object_delete', $options, true)) {
+            $cacheKey= $this->getCacheKey($key, array_merge($options, array('cache_ext' => '')));
+            if (file_exists($cacheKey) && is_dir($cacheKey)) {
+                $results = $this->xpdo->cacheManager->deleteTree($cacheKey, array_merge(array('deleteTop' => false, 'skipDirs' => false, 'extensions' => array('.cache.php')), $options));
+                if ($results !== false) {
+                    $deleted = true;
+                }
             }
-        } else {
-            $cacheKey= $this->getCacheKey($key, $options);
-            if (file_exists($cacheKey)) {
-                $deleted= @ unlink($cacheKey);
-            }
+        }
+        $cacheKey= $this->getCacheKey($key, $options);
+        if (file_exists($cacheKey)) {
+            $deleted= @ unlink($cacheKey);
         }
         return $deleted;
     }


### PR DESCRIPTION
Other xPDOCache implementations check for the `multiple_object_delete` option before attempting to recursively remove cache entries that match the cache key provided to the delete() method. xPDOFileCache was not doing this, and further, if a directory existed with the cache key to be deleted, the directory was emptied of cache entries but the actual cache entry that was meant to be deleted was left in place.

Resolves #170 for 2.x branch