### PR TITLE
Fix xPDOFileCache->delete() when a directory with same cache key exists

### DIFF
--- a/src/xPDO/Cache/xPDOAPCCache.php
+++ b/src/xPDO/Cache/xPDOAPCCache.php
@@ -62,14 +62,19 @@ class xPDOAPCCache extends xPDOCache {
 
     public function delete($key, $options= array()) {
         $deleted = false;
-        if (!isset($options['multiple_object_delete']) || empty($options['multiple_object_delete'])) {
-            $deleted= apc_delete($this->getCacheKey($key));
-        } elseif (class_exists('APCIterator', true)) {
-            $iterator = new APCIterator('user', '/^' . str_replace('/', '\/', $this->getCacheKey($key)) . '/', APC_ITER_KEY);
-            if ($iterator) {
-                $deleted = apc_delete($iterator);
+        if ($this->getOption(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE, $options, false)) {
+            if (class_exists('APCIterator', true)) {
+                $iterator = new APCIterator('user', '/^' . str_replace('/', '\/', $this->getCacheKey($key)) . '/', APC_ITER_KEY);
+                if ($iterator) {
+                    $deleted = apc_delete($iterator);
+                }
+            } else {
+                $deleted = $this->flush($options);
             }
+        } else {
+            $deleted = apc_delete($this->getCacheKey($key));
         }
+
         return $deleted;
     }
 

--- a/src/xPDO/Cache/xPDOFileCache.php
+++ b/src/xPDO/Cache/xPDOFileCache.php
@@ -86,17 +86,18 @@ class xPDOFileCache extends xPDOCache {
 
     public function delete($key, $options= array()) {
         $deleted= false;
-        $cacheKey= $this->getCacheKey($key, array_merge($options, array('cache_ext' => '')));
-        if (file_exists($cacheKey) && is_dir($cacheKey)) {
-            $results = $this->xpdo->cacheManager->deleteTree($cacheKey, array_merge(array('deleteTop' => false, 'skipDirs' => false, 'extensions' => array('.cache.php')), $options));
-            if ($results !== false) {
-                $deleted = true;
+        if ($this->getOption(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE, $options, false)) {
+            $cacheKey= $this->getCacheKey($key, array_merge($options, array('cache_ext' => '')));
+            if (file_exists($cacheKey) && is_dir($cacheKey)) {
+                $results = $this->xpdo->cacheManager->deleteTree($cacheKey, array_merge(array('deleteTop' => false, 'skipDirs' => false, 'extensions' => array('.cache.php')), $options));
+                if ($results !== false) {
+                    $deleted = true;
+                }
             }
-        } else {
-            $cacheKey= $this->getCacheKey($key, $options);
-            if (file_exists($cacheKey)) {
-                $deleted= @ unlink($cacheKey);
-            }
+        }
+        $cacheKey= $this->getCacheKey($key, $options);
+        if (file_exists($cacheKey)) {
+            $deleted= @ unlink($cacheKey);
         }
         return $deleted;
     }

--- a/src/xPDO/Cache/xPDOMemCache.php
+++ b/src/xPDO/Cache/xPDOMemCache.php
@@ -84,11 +84,12 @@ class xPDOMemCache extends xPDOCache {
     }
 
     public function delete($key, $options= array()) {
-        if (!isset($options['multiple_object_delete']) || empty($options['multiple_object_delete'])) {
-            $deleted= $this->memcache->delete($this->getCacheKey($key));
-        } else {
+        if ($this->getOption(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE, $options, false)) {
             $deleted= $this->flush($options);
+        } else {
+            $deleted= $this->memcache->delete($this->getCacheKey($key));
         }
+
         return $deleted;
     }
 

--- a/src/xPDO/Cache/xPDOMemCached.php
+++ b/src/xPDO/Cache/xPDOMemCached.php
@@ -72,11 +72,12 @@ class xPDOMemCached extends xPDOCache {
     }
 
     public function delete($key, $options= array()) {
-        if (!isset($options['multiple_object_delete']) || empty($options['multiple_object_delete'])) {
-            $deleted= $this->memcached->delete($this->getCacheKey($key));
-        } else {
+        if ($this->getOption(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE, $options, false)) {
             $deleted= $this->flush($options);
+        } else {
+            $deleted= $this->memcached->delete($this->getCacheKey($key));
         }
+
         return $deleted;
     }
 

--- a/src/xPDO/Cache/xPDORedisCache.php
+++ b/src/xPDO/Cache/xPDORedisCache.php
@@ -65,11 +65,12 @@ class xPDORedisCache extends xPDOCache {
     }
 
     public function delete($key, $options= array()) {
-        if (!isset($options['multiple_object_delete']) || empty($options['multiple_object_delete'])) {
-            $deleted= $this->redis->delete($this->getCacheKey($key));
-        } else {
+        if ($this->getOption(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE, $options, false)) {
             $deleted= $this->flush($options);
+        } else {
+            $deleted= $this->redis->delete($this->getCacheKey($key));
         }
+
         return $deleted;
     }
 

--- a/src/xPDO/Cache/xPDOWinCache.php
+++ b/src/xPDO/Cache/xPDOWinCache.php
@@ -62,11 +62,12 @@ class xPDOWinCache extends xPDOCache {
 
     public function delete($key, $options= array()) {
         $deleted = false;
-        if (!isset($options['multiple_object_delete']) || empty($options['multiple_object_delete'])) {
-            $deleted= wincache_ucache_delete($this->getCacheKey($key));
-        } else {
+        if ($this->getOption(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE, $options, false)) {
             $deleted= $this->flush($options);
+        } else {
+            $deleted= wincache_ucache_delete($this->getCacheKey($key));
         }
+
         return $deleted;
     }
 

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -1708,7 +1708,7 @@ class xPDOObject {
                                 xPDO::OPT_CACHE_PREFIX => $this->getOption('cache_db_prefix', null, xPDOCacheManager::CACHE_DIR)
                             )
                         );
-                        if (!$dbCache->delete($this->_class, array('multiple_object_delete' => true))) {
+                        if (!$dbCache->delete($this->_class, array(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE => true))) {
                             $this->xpdo->log(xPDO::LOG_LEVEL_WARN, "Could not remove cache entries for {$this->_class}", '', __METHOD__, __FILE__, __LINE__);
                         }
                     }

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -76,6 +76,7 @@ class xPDO {
     const OPT_CACHE_KEY = 'cache_key';
     const OPT_CACHE_PATH = 'cache_path';
     const OPT_CACHE_PREFIX = 'cache_prefix';
+    const OPT_CACHE_MULTIPLE_OBJECT_DELETE = 'multiple_object_delete';
     const OPT_CACHE_ATTEMPTS = 'cache_attempts';
     const OPT_CACHE_ATTEMPT_DELAY = 'cache_attempt_delay';
     const OPT_CALLBACK_ON_REMOVE = 'callback_on_remove';
@@ -907,7 +908,7 @@ class xPDO {
                                     xPDO::OPT_CACHE_HANDLER => $this->getOption(xPDO::OPT_CACHE_DB_HANDLER, null, $this->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDO\\Cache\\xPDOFileCache')),
                                     xPDO::OPT_CACHE_FORMAT => (integer) $this->getOption('cache_db_format', null, $this->getOption(xPDO::OPT_CACHE_FORMAT, null, Cache\xPDOCacheManager::CACHE_PHP)),
                                     xPDO::OPT_CACHE_PREFIX => $this->getOption('cache_db_prefix', null, Cache\xPDOCacheManager::CACHE_DIR),
-                                    'multiple_object_delete' => true
+                                    xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE => true
                                 ));
                             }
                         }
@@ -944,7 +945,7 @@ class xPDO {
                         } else {
                             $removed= true;
                             if ($this->getOption(xPDO::OPT_CACHE_DB)) {
-                                $this->cacheManager->delete(Cache\xPDOCacheManager::CACHE_DIR . $query->getAlias(), array('multiple_object_delete' => true));
+                                $this->cacheManager->delete(Cache\xPDOCacheManager::CACHE_DIR . $query->getAlias(), array(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE => true));
                             }
                             $callback = $this->getOption(xPDO::OPT_CALLBACK_ON_REMOVE);
                             if ($callback && is_callable($callback)) {
@@ -983,7 +984,7 @@ class xPDO {
                         $this->log(xPDO::LOG_LEVEL_ERROR, "xPDO->removeCollection - Error deleting {$className} instances using query " . $query->toSQL());
                     } else {
                         if ($this->getOption(xPDO::OPT_CACHE_DB)) {
-                            $this->cacheManager->delete(Cache\xPDOCacheManager::CACHE_DIR . $query->getAlias(), array('multiple_object_delete' => true));
+                            $this->cacheManager->delete(Cache\xPDOCacheManager::CACHE_DIR . $query->getAlias(), array(xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE => true));
                         }
                         $callback = $this->getOption(xPDO::OPT_CALLBACK_ON_REMOVE);
                         if ($callback && is_callable($callback)) {
@@ -2374,7 +2375,7 @@ class xPDO {
                                         xPDO::OPT_CACHE_FORMAT => (integer) $this->getOption('cache_db_format', $options, $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, Cache\xPDOCacheManager::CACHE_PHP)),
                                         xPDO::OPT_CACHE_EXPIRES => (integer) $this->getOption(xPDO::OPT_CACHE_DB_EXPIRES, null, $this->getOption(xPDO::OPT_CACHE_EXPIRES, null, 0)),
                                         xPDO::OPT_CACHE_PREFIX => $this->getOption('cache_db_prefix', $options, Cache\xPDOCacheManager::CACHE_DIR),
-                                        'multiple_object_delete' => true
+                                        xPDO::OPT_CACHE_MULTIPLE_OBJECT_DELETE => true
                                     )));
                                     if ($this->getDebug() === true) {
                                         $this->log(xPDO::LOG_LEVEL_DEBUG, "Removing all cache objects of class {$gClass}: " . ($removed ? 'successful' : 'failed'));


### PR DESCRIPTION
Other xPDOCache implementations check for the multiple_object_delete option before attempting to recursively remove cache entries that match the cache key provided to the delete() method. xPDOFileCache was not doing this, and further, if a directory existed with the cache key to be deleted, the directory was emptied of cache entries but the actual cache entry that was meant to be deleted was left in place.

Resolves #170 for 3.x branch