### PR TITLE
Add __debugInfo magic method 

### DIFF
--- a/src/xPDO/Om/xPDOCriteria.php
+++ b/src/xPDO/Om/xPDOCriteria.php
@@ -163,4 +163,12 @@ class xPDOCriteria {
         }
         return $sql;
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'sql' => $this->toSQL(),
+            'bindings' => $this->bindings,
+        ];
+    }
 }

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -2551,4 +2551,32 @@ class xPDOObject {
         }
         return $aliases;
     }
+
+    /**
+     * Allows dumping xPDOObject instances with var_dump/print_r without running out of memory.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'new' => $this->isNew(),
+            'fields' => $this->toArray(),
+            '_class' => $this->_class,
+            '_package' => $this->_package,
+
+            '_alias' => $this->_alias,
+            '_pk' => $this->_pk,
+            '_pktype' => $this->_pktype,
+            '_table' => $this->_table,
+            '_tableMeta' => $this->_tableMeta,
+
+            '_dirty' => $this->_dirty,
+            '_lazy' => $this->_lazy,
+            '_fields' => $this->_fields,
+            '_fieldMeta' => $this->_fieldMeta,
+            '_fieldNames' => $this->fieldNames,
+            '_fieldAliases' => $this->_fieldAliases,
+        ];
+    }
 }

--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -911,4 +911,17 @@ abstract class xPDOQuery extends xPDOCriteria {
         $this->bindings= $criteria->bindings;
         $this->cacheFlag= $criteria->cacheFlag;
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'class' => $this->_class,
+            'alias' => $this->_alias,
+            'tableClass' => $this->_tableClass,
+            'graph' => $this->graph,
+            'query' => $this->query,
+            'sql' => $this->toSQL(),
+            'bindings' => $this->bindings,
+        ];
+    }
 }

--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -915,9 +915,9 @@ abstract class xPDOQuery extends xPDOCriteria {
     public function __debugInfo()
     {
         return [
-            'class' => $this->_class,
-            'alias' => $this->_alias,
-            'tableClass' => $this->_tableClass,
+            '_class' => $this->_class,
+            '_alias' => $this->_alias,
+            '_tableClass' => $this->_tableClass,
             'graph' => $this->graph,
             'query' => $this->query,
             'sql' => $this->toSQL(),

--- a/src/xPDO/xPDOIterator.php
+++ b/src/xPDO/xPDOIterator.php
@@ -127,4 +127,17 @@ class xPDOIterator implements \Iterator {
             $this->current = null;
         }
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'index' => $this->index,
+            'current' => $this->current,
+            'stmt' => $this->stmt,
+            'class' => $this->class,
+            'alias' => $this->alias,
+            'criteria' => $this->criteria,
+            'criteriaType' => $this->criteriaType,
+        ];
+    }
 }


### PR DESCRIPTION
Requested @ https://github.com/modxcms/revolution/issues/14941

This adds the `__debugInfo()` magic method to what I suspect are the most common xPDO objects that people might try to be inspecting with a `var_dump` or `print_r` statement. 

Before, that could cause recursion and running out of memory on large objects. With this patch, it will return a much simpler representation. 

It's probably worth adding a couple of more specific ones in the MODX repo as well, for things like resources (including the `_output` for example) or elements. 

As a simple test case, I've used the following snippet in MODX 3.x:

```
echo '<pre>';

// --

$c = $modx->newQuery('modResource');
$c->where(['deleted' => false]);
$c->sortby('menuindex', 'ASC');
//$c->prepare();
var_dump($c);

$iterator = $modx->getIterator('modResource', $c);
var_dump($iterator);

// -- 

var_dump($modx->resource);

echo '</pre>';
```

(For the xPDOQuery one to show the sql query, calling prepare is needed before the dump.)