### PR TITLE
Fixing 500 error in xPDORedisCache class

### DIFF
--- a/src/xPDO/Cache/xPDORedisCache.php
+++ b/src/xPDO/Cache/xPDORedisCache.php
@@ -9,6 +9,8 @@
  */
 namespace xPDO\Cache;
 use xPDO\xPDO;
+use Redis;
+
 /**
  * Provides a redis-powered xPDOCache implementation.
  *


### PR DESCRIPTION
This fixes the "Class 'xPDO\Cache\Redis' not found in ..." 500 error