### PR TITLE
Add missing use statements to prevent undefined class errors

### DIFF
--- a/src/xPDO/Cache/xPDOAPCCache.php
+++ b/src/xPDO/Cache/xPDOAPCCache.php
@@ -10,6 +10,7 @@
 
 namespace xPDO\Cache;
 
+use APCIterator;
 use xPDO\xPDO;
 
 /**

--- a/src/xPDO/Cache/xPDOMemCache.php
+++ b/src/xPDO/Cache/xPDOMemCache.php
@@ -10,6 +10,7 @@
 
 namespace xPDO\Cache;
 
+use Memcache;
 use xPDO\xPDO;
 
 /**


### PR DESCRIPTION
I noticed some undefined classes. 