### PR TITLE
Fix an issue with default CURRENT TIMESTAMP value

### DIFF
--- a/xpdo/om/mysql/xpdodriver.class.php
+++ b/xpdo/om/mysql/xpdodriver.class.php
@@ -47,6 +47,7 @@ class xPDODriver_mysql extends xPDODriver {
     public $_currentTimestamps= array (
         'CURRENT_TIMESTAMP',
         'CURRENT_TIMESTAMP()',
+        'current_timestamp()',
         'NOW()',
         'LOCALTIME',
         'LOCALTIME()',


### PR DESCRIPTION
When generating a schema based on the INFORMATION_SCHEMA.COLUMNS table, a default CURRENT TIMESTAMP is displayed as CURRENT_TIMESTAMP up until MariaDB 10.2.2, and as current_timestamp() from MariaDB 10.2.3, due to to MariaDB 10.2 accepting expressions in the DEFAULT clause.

Related issue: #130 