### PR TITLE
Fix error merging driverOptions when creating an xPDOConnection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ This file shows the changes in this release of xPDO.
 
 xPDO 3.0.0 (TBD)
 ====================================
+- Fix error merging driverOptions when creating an xPDOConnection
 - Add float phptype to quotable list to prevent quoting floats as integer
 - Add ability to define RegEx excludes in xPDOZip->pack()
 - Fix bug when generating platform files from classes with constants

--- a/src/xPDO/xPDOConnection.php
+++ b/src/xPDO/xPDOConnection.php
@@ -55,7 +55,7 @@ class xPDOConnection {
         $this->config['password']= $password;
         $driverOptions = is_array($driverOptions) ? $driverOptions : array();
         if (array_key_exists('driverOptions', $this->config) && is_array($this->config['driverOptions'])) {
-            $driverOptions = array_merge($this->config['driverOptions'], $driverOptions);
+            $driverOptions = $driverOptions + $this->config['driverOptions'];
         }
         $this->config['driverOptions']= $driverOptions;
         if (array_key_exists(xPDO::OPT_CONN_MUTABLE, $this->config)) {
@@ -81,7 +81,7 @@ class xPDOConnection {
     public function connect($driverOptions = array()) {
         if ($this->pdo === null) {
             if (is_array($driverOptions) && !empty($driverOptions)) {
-                $this->config['driverOptions']= array_merge($this->config['driverOptions'], $driverOptions);
+                $this->config['driverOptions']= $driverOptions + $this->config['driverOptions'];
             }
             try {
                 $this->pdo= new \PDO($this->config['dsn'], $this->config['username'], $this->config['password'], $this->config['driverOptions']);

--- a/test/xPDO/Test/xPDOIteratorTest.php
+++ b/test/xPDO/Test/xPDOIteratorTest.php
@@ -20,7 +20,7 @@ class xPDOIteratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->xpdo->manager->createObjectContainer('xPDO\Test\Sample\SecureItem');
+        $this->xpdo->getManager()->createObjectContainer('xPDO\Test\Sample\SecureItem');
 
         $i = 1;
         while ($i < 11) {

--- a/test/xPDO/Test/xPDOTest.php
+++ b/test/xPDO/Test/xPDOTest.php
@@ -38,6 +38,15 @@ class xPDOTest extends TestCase
     }
 
     /**
+     * Verify setting driverOptions via xPDO::connect works.
+     */
+    public function testDriverOptions()
+    {
+        $this->xpdo->connect([\PDO::ATTR_ERRMODE => \PDO::ERRMODE_WARNING]);
+        $this->assertEquals(\PDO::ERRMODE_WARNING, $this->xpdo->getAttribute(\PDO::ATTR_ERRMODE));
+    }
+
+    /**
      * Test table creation.
      */
     public function testCreateObjectContainer()

--- a/test/xPDO/TestCase.php
+++ b/test/xPDO/TestCase.php
@@ -67,7 +67,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        $this->xpdo = self::getInstance();
+        $this->xpdo = self::getInstance(true);
         $this->xpdo->setPackage('xPDO\\Test\\Sample', self::$properties['xpdo_test_path'] . 'model/');
     }
 


### PR DESCRIPTION
When creating an xPDOConnection, xPDO was attempting to merge driverOptions stored in xPDO config with any provided at the time a connection (i.e. PDO instance) was created. This was failing to work properly because it was using array_merge on a numerically indexed array of driverOptions, which reindexes the array starting at 0, effectively wiping out which attribute was being set to a specific value.