### PR TITLE
Refactor unit tests to use Yoast/PHPUnitPolyfills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # ignore composer.lock
 composer.lock
+
+# ignore phpunit cache files
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ jobs:
     - php: 7.4
       env: TEST_DRIVER=sqlite
 
+    - php: 8.0
+      env: TEST_DRIVER=sqlite
+
     - php: 5.6
       env: TEST_DRIVER=mysql
       services: mysql
@@ -59,6 +62,10 @@ jobs:
       env: TEST_DRIVER=mysql
       services: mysql
 
+    - php: 8.0
+      env: TEST_DRIVER=mysql
+      services: mysql
+
     - php: 5.6
       env: TEST_DRIVER=pgsql
       services: postgresql
@@ -90,6 +97,12 @@ jobs:
         postgresql: "9.6"
 
     - php: 7.4
+      env: TEST_DRIVER=pgsql
+      services: postgresql
+      addons:
+        postgresql: "9.6"
+
+    - php: 8.0
       env: TEST_DRIVER=pgsql
       services: postgresql
       addons:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7|~6.5"
+        "yoast/phpunit-polyfills": "^0.2.0"
     },
     "suggest": {
         "ext-redis": "Allows caching using Redis"

--- a/test/properties.sample.inc.php
+++ b/test/properties.sample.inc.php
@@ -17,7 +17,7 @@ $properties['mysql_string_dsn_nodb']= 'mysql:host=localhost;charset=utf8';
 $properties['mysql_string_dsn_error']= 'mysql:host= nonesuchhost;dbname=nonesuchdb';
 $properties['mysql_string_username']= '';
 $properties['mysql_string_password']= '';
-$properties['mysql_array_driverOptions']= array();
+$properties['mysql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['mysql_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] .'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,
@@ -43,7 +43,7 @@ $properties['pgsql_string_dsn_nodb']= 'pgsql:host=localhost';
 $properties['pgsql_string_dsn_error']= 'pgsql:host= nonesuchhost;dbname=nonesuchdb';
 $properties['pgsql_string_username']= '';
 $properties['pgsql_string_password']= '';
-$properties['pgsql_array_driverOptions']= array();
+$properties['pgsql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['pgsql_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] .'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,
@@ -69,7 +69,7 @@ $properties['sqlite_string_dsn_nodb']= 'sqlite::memory:';
 $properties['sqlite_string_dsn_error']= 'sqlite:db/';
 $properties['sqlite_string_username']= '';
 $properties['sqlite_string_password']= '';
-$properties['sqlite_array_driverOptions']= array();
+$properties['sqlite_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['sqlite_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] . 'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,
@@ -95,7 +95,7 @@ $properties['sqlsrv_string_dsn_nodb']= 'sqlsrv:server=(local)';
 $properties['sqlsrv_string_dsn_error']= 'sqlsrv:server=xyz;123';
 $properties['sqlsrv_string_username']= '';
 $properties['sqlsrv_string_password']= '';
-$properties['sqlsrv_array_driverOptions']= array(/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/);
+$properties['sqlsrv_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['sqlsrv_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] . 'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,

--- a/test/properties.travis.inc.php
+++ b/test/properties.travis.inc.php
@@ -17,7 +17,7 @@ $properties['mysql_string_dsn_nodb']= 'mysql:host=localhost;charset=utf8';
 $properties['mysql_string_dsn_error']= 'mysql:host= nonesuchhost;dbname=nonesuchdb';
 $properties['mysql_string_username']= 'travis';
 $properties['mysql_string_password']= '';
-$properties['mysql_array_driverOptions']= array();
+$properties['mysql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['mysql_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] .'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,
@@ -43,7 +43,7 @@ $properties['pgsql_string_dsn_nodb']= 'pgsql:host=localhost';
 $properties['pgsql_string_dsn_error']= 'pgsql:host= nonesuchhost;dbname=nonesuchdb';
 $properties['pgsql_string_username']= 'postgres';
 $properties['pgsql_string_password']= '';
-$properties['pgsql_array_driverOptions']= array();
+$properties['pgsql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['pgsql_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] .'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,
@@ -69,7 +69,7 @@ $properties['sqlite_string_dsn_nodb']= 'sqlite::memory:';
 $properties['sqlite_string_dsn_error']= 'sqlite:db/';
 $properties['sqlite_string_username']= '';
 $properties['sqlite_string_password']= '';
-$properties['sqlite_array_driverOptions']= array();
+$properties['sqlite_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['sqlite_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] . 'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,
@@ -95,7 +95,7 @@ $properties['sqlsrv_string_dsn_nodb']= 'sqlsrv:server=(local)';
 $properties['sqlsrv_string_dsn_error']= 'sqlsrv:server=xyz;123';
 $properties['sqlsrv_string_username']= '';
 $properties['sqlsrv_string_password']= '';
-$properties['sqlsrv_array_driverOptions']= array(/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/);
+$properties['sqlsrv_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 $properties['sqlsrv_array_options']= array(
     xPDO::OPT_CACHE_PATH => $properties['xpdo_test_path'] . 'cache/',
     xPDO::OPT_HYDRATE_FIELDS => true,

--- a/test/xPDO/Legacy/Cache/xPDOCacheDbTest.php
+++ b/test/xPDO/Legacy/Cache/xPDOCacheDbTest.php
@@ -22,10 +22,12 @@ class xPDOCacheDbTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -103,8 +105,10 @@ class xPDOCacheDbTest extends TestCase
 
     /**
      * Remove dummy data prior to each test.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         try {
             $this->xpdo->manager->removeObjectContainer('Phone');
@@ -114,7 +118,7 @@ class xPDOCacheDbTest extends TestCase
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/Om/xPDOObjectSingleTableInheritanceTest.php
+++ b/test/xPDO/Legacy/Om/xPDOObjectSingleTableInheritanceTest.php
@@ -23,10 +23,12 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -120,8 +122,10 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
 
     /**
      * Remove dummy data prior to each test.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         try {
             $this->xpdo->manager->removeObjectContainer('sti.baseClass');
@@ -130,7 +134,7 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/Om/xPDOObjectTest.php
+++ b/test/xPDO/Legacy/Om/xPDOObjectTest.php
@@ -23,10 +23,12 @@ class xPDOObjectTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -125,8 +127,10 @@ class xPDOObjectTest extends TestCase
 
     /**
      * Remove dummy data after each test.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         try {
             $this->xpdo->manager->removeObjectContainer('Phone');
@@ -136,7 +140,7 @@ class xPDOObjectTest extends TestCase
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/Om/xPDOQueryHavingTest.php
+++ b/test/xPDO/Legacy/Om/xPDOQueryHavingTest.php
@@ -23,10 +23,12 @@ class xPDOQueryHavingTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -51,12 +53,14 @@ class xPDOQueryHavingTest extends TestCase
 
     /**
      * Clean up data when through.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         $this->xpdo->getManager();
         $this->xpdo->manager->removeObjectContainer('Item');
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/Om/xPDOQueryLimitTest.php
+++ b/test/xPDO/Legacy/Om/xPDOQueryLimitTest.php
@@ -22,10 +22,12 @@ class xPDOQueryLimitTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -50,12 +52,14 @@ class xPDOQueryLimitTest extends TestCase
 
     /**
      * Clean up data when through.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         $this->xpdo->getManager();
         $this->xpdo->manager->removeObjectContainer('Item');
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/Om/xPDOQuerySortByTest.php
+++ b/test/xPDO/Legacy/Om/xPDOQuerySortByTest.php
@@ -22,9 +22,11 @@ use xPDO\xPDO;
 class xPDOQuerySortByTest extends TestCase {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp() {
-        parent::setUp();
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -50,11 +52,13 @@ class xPDOQuerySortByTest extends TestCase {
 
     /**
      * Clean up data when through.
+     *
+     * @after
      */
-    public function tearDown() {
+    public function tearDownFixtures() {
     	$this->xpdo->getManager();
         $this->xpdo->manager->removeObjectContainer('Item');
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/Om/xPDOQueryTest.php
+++ b/test/xPDO/Legacy/Om/xPDOQueryTest.php
@@ -24,9 +24,11 @@ use xPDO\xPDO;
 class xPDOQueryTest extends TestCase {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp() {
-        parent::setUp();
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -93,8 +95,10 @@ class xPDOQueryTest extends TestCase {
 
     /**
      * Remove dummy data prior to each test.
+     *
+     * @after
      */
-    public function tearDown() {
+    public function tearDownFixtures() {
         try {
             $this->xpdo->manager->removeObjectContainer('Phone');
             $this->xpdo->manager->removeObjectContainer('Person');
@@ -103,7 +107,7 @@ class xPDOQueryTest extends TestCase {
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Legacy/TestCase.php
+++ b/test/xPDO/Legacy/TestCase.php
@@ -11,8 +11,9 @@
 namespace xPDO\Legacy;
 
 use xPDO\xPDO;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends XTestCase
 {
     /**
      * @var xPDO A static xPDO fixture.
@@ -30,8 +31,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Setup static properties when loading the test cases.
+     *
+     * @beforeClass
      */
-    public static function setUpBeforeClass()
+    public static function setUpFixturesBeforeClass()
     {
         self::$properties = include(__DIR__ . '/../../properties.inc.php');
     }
@@ -66,8 +69,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Set up the xPDO fixture for each test case.
+     *
+     * @before
      */
-    protected function setUp()
+    public function setUpFixtures()
     {
         $this->xpdo = self::getInstance();
         $this->xpdo->setPackage('sample', self::$properties['xpdo_test_path'] . 'model/');
@@ -75,8 +80,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Tear down the xPDO fixture after each test case.
+     *
+     * @after
      */
-    protected function tearDown()
+    public function tearDownFixtures()
     {
         $this->xpdo = null;
     }

--- a/test/xPDO/Test/Cache/xPDOCacheDbTest.php
+++ b/test/xPDO/Test/Cache/xPDOCacheDbTest.php
@@ -22,10 +22,12 @@ class xPDOCacheDbTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -103,8 +105,10 @@ class xPDOCacheDbTest extends TestCase
 
     /**
      * Remove dummy data prior to each test.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         try {
             $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Phone');
@@ -114,7 +118,7 @@ class xPDOCacheDbTest extends TestCase
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/Compression/xPDOZipTest.php
+++ b/test/xPDO/Test/Compression/xPDOZipTest.php
@@ -21,9 +21,12 @@ use xPDO\xPDO;
  */
 class xPDOZipTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpFixturesBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::setUpFixturesBeforeClass();
         $xpdo = self::getInstance();
 
         $zipPath = self::$properties['xpdo_test_path'] . "fs/zip/";
@@ -46,7 +49,10 @@ class xPDOZipTest extends TestCase
         $xpdo->getCacheManager()->writeTree($unzipPath);
     }
 
-    public static function tearDownAfterClass()
+    /**
+     * @afterClass
+     */
+    public static function tearDownFixturesAfterClass()
     {
         $xpdo = self::getInstance();
         $paths = array(

--- a/test/xPDO/Test/Om/xPDOObjectSingleTableInheritanceTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectSingleTableInheritanceTest.php
@@ -23,10 +23,12 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -120,8 +122,10 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
 
     /**
      * Remove dummy data prior to each test.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         try {
             $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\STI\\baseClass');
@@ -130,7 +134,7 @@ class xPDOObjectSingleTableInheritanceTest extends TestCase
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/Om/xPDOObjectTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectTest.php
@@ -23,10 +23,12 @@ class xPDOObjectTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -125,8 +127,10 @@ class xPDOObjectTest extends TestCase
 
     /**
      * Remove dummy data after each test.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         try {
             $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Phone');
@@ -136,7 +140,7 @@ class xPDOObjectTest extends TestCase
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/Om/xPDOQueryConditionsTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryConditionsTest.php
@@ -17,9 +17,12 @@ use xPDO\xPDO;
 
 class xPDOQueryConditionsTest extends TestCase
 {
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
 
         try {
             $this->xpdo->getManager();
@@ -46,9 +49,12 @@ class xPDOQueryConditionsTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
     {
-        parent::tearDown();
+        parent::tearDownFixtures();
 
         try {
             $this->xpdo->manager->removeObjectContainer('xPDO\Test\Sample\xPDOSample');

--- a/test/xPDO/Test/Om/xPDOQueryHavingTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryHavingTest.php
@@ -23,10 +23,12 @@ class xPDOQueryHavingTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -51,12 +53,14 @@ class xPDOQueryHavingTest extends TestCase
 
     /**
      * Clean up data when through.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         $this->xpdo->getManager();
         $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Item');
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/Om/xPDOQueryLimitTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryLimitTest.php
@@ -22,10 +22,12 @@ class xPDOQueryLimitTest extends TestCase
 {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp()
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -50,12 +52,14 @@ class xPDOQueryLimitTest extends TestCase
 
     /**
      * Clean up data when through.
+     *
+     * @after
      */
-    public function tearDown()
+    public function tearDownFixtures()
     {
         $this->xpdo->getManager();
         $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Item');
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/Om/xPDOQuerySortByTest.php
+++ b/test/xPDO/Test/Om/xPDOQuerySortByTest.php
@@ -22,9 +22,11 @@ use xPDO\xPDO;
 class xPDOQuerySortByTest extends TestCase {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp() {
-        parent::setUp();
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -50,11 +52,13 @@ class xPDOQuerySortByTest extends TestCase {
 
     /**
      * Clean up data when through.
+     *
+     * @after
      */
-    public function tearDown() {
+    public function tearDownFixtures() {
     	$this->xpdo->getManager();
         $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Item');
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/Om/xPDOQueryTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryTest.php
@@ -24,9 +24,11 @@ use xPDO\xPDO;
 class xPDOQueryTest extends TestCase {
     /**
      * Setup dummy data for each test.
+     *
+     * @before
      */
-    public function setUp() {
-        parent::setUp();
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         try {
             /* ensure we have clear data and identity sequences */
             $this->xpdo->getManager();
@@ -93,8 +95,10 @@ class xPDOQueryTest extends TestCase {
 
     /**
      * Remove dummy data prior to each test.
+     *
+     * @after
      */
-    public function tearDown() {
+    public function tearDownFixtures() {
         try {
             $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Phone');
             $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\Person');
@@ -103,7 +107,7 @@ class xPDOQueryTest extends TestCase {
         } catch (\Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     /**

--- a/test/xPDO/Test/PSR4/TestCase.php
+++ b/test/xPDO/Test/PSR4/TestCase.php
@@ -13,7 +13,10 @@ namespace xPDO\Test\PSR4;
 
 class TestCase extends \xPDO\TestCase
 {
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
         $this->xpdo = self::getInstance(true);
         $this->xpdo->setPackage('xPDO\Test\Sample', self::$properties['xpdo_test_path'] . 'model/PSR4/', null, 'xPDO\\Test\\');

--- a/test/xPDO/Test/xPDOIteratorTest.php
+++ b/test/xPDO/Test/xPDOIteratorTest.php
@@ -16,9 +16,12 @@ use xPDO\xPDO;
 
 class xPDOIteratorTest extends TestCase
 {
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
 
         $this->xpdo->getManager()->createObjectContainer('xPDO\Test\Sample\SecureItem');
 
@@ -32,11 +35,14 @@ class xPDOIteratorTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
     {
         $this->xpdo->manager->removeObjectContainer('xPDO\Test\Sample\SecureItem');
 
-        parent::tearDown();
+        parent::tearDownFixtures();
     }
 
     public function testIteratorDoesNotFailIfRowExistsButObjectCanNotBeLoaded()

--- a/test/xPDO/TestCase.php
+++ b/test/xPDO/TestCase.php
@@ -10,7 +10,9 @@
 
 namespace xPDO;
 
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
+
+abstract class TestCase extends XTestCase
 {
     /**
      * @var xPDO A static xPDO fixture.
@@ -28,8 +30,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Setup static properties when loading the test cases.
+     *
+     * @beforeClass
      */
-    public static function setUpBeforeClass()
+    public static function setUpFixturesBeforeClass()
     {
         self::$properties = include(__DIR__ . '/../properties.inc.php');
     }
@@ -64,8 +68,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Set up the xPDO fixture for each test case.
+     *
+     * @before
      */
-    protected function setUp()
+    public function setUpFixtures()
     {
         $this->xpdo = self::getInstance(true);
         $this->xpdo->setPackage('xPDO\\Test\\Sample', self::$properties['xpdo_test_path'] . 'model/');
@@ -73,8 +79,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Tear down the xPDO fixture after each test case.
+     *
+     * @after
      */
-    protected function tearDown()
+    public function tearDownFixtures()
     {
         $this->xpdo = null;
     }


### PR DESCRIPTION
This will allow writing tests for PHPUnit 9 and supporting PHP 8 while still allowing the same test suite to run with older versions of PHPUnit in order to support legacy PHP releases currently still supported by xPDO.
