### PR TITLE
Improve log message "Encountered empty IN condition with key id"

### DIFF
--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -70,6 +70,7 @@ abstract class xPDOQuery extends xPDOCriteria {
     protected $_class= null;
     protected $_alias= null;
     protected $_tableClass = null;
+    protected $errors = [];
     public $graph= array ();
     public $query= array (
         'command' => 'SELECT',
@@ -663,6 +664,10 @@ abstract class xPDOQuery extends xPDOCriteria {
         } else {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not construct or prepare query because it is invalid or could not connect: ' . $this->sql);
         }
+        if (!empty($this->errors)) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, implode("\r\n", $this->errors) . "\r\nQuery: " . $this->sql);
+        }
+
         return $this->stmt;
     }
 
@@ -776,7 +781,7 @@ abstract class xPDOQuery extends xPDOCriteria {
                                     }
                                 }
                                 if (empty($vals)) {
-                                    $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Encountered empty {$operator} condition with key {$key}");
+                                    $this->errors[] = "Encountered empty {$operator} condition with key {$key}.";
                                 }
                                 $val = "(" . implode(',', $vals) . ")";
                                 $sql = "{$this->xpdo->escape($alias)}.{$this->xpdo->escape($key)} {$operator} {$val}";


### PR DESCRIPTION
### What does it do?
Improve log message "Encountered empty IN condition with key id".

### How to test
1. Try to execute the code. modalConsole can be used to do this.
```
$q = $modx->newQuery('modUser');
$q->where(['id:IN' => []]);
$q->prepare();
```
2. Open the MODX error log. 
```
[2021-03-06 17:41:24] (ERROR @ D:\Projects\modx.local\www\core\xpdo\om\xpdoquery.class.php : 656) Encountered empty IN condition with key id.
Query: SELECT `modUser`.`id` AS `modUser_id`, `modUser`.`username` AS `modUser_username`, `modUser`.`password` AS `modUser_password`, `modUser`.`cachepwd` AS `modUser_cachepwd`, `modUser`.`class_key` AS `modUser_class_key`, `modUser`.`active` AS `modUser_active`, `modUser`.`remote_key` AS `modUser_remote_key`, `modUser`.`remote_data` AS `modUser_remote_data`, `modUser`.`hash_class` AS `modUser_hash_class`, `modUser`.`salt` AS `modUser_salt`, `modUser`.`primary_group` AS `modUser_primary_group`, `modUser`.`session_stale` AS `modUser_session_stale`, `modUser`.`sudo` AS `modUser_sudo`, `modUser`.`createdon` AS `modUser_createdon` FROM `modx_users` AS `modUser` WHERE `modUser`.`id` IN () 
```

### Related issue(s)/PR(s)
#155