### PR TITLE
Prevent unexpected results with non-conditional string condition

### DIFF
--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -818,7 +818,7 @@ abstract class xPDOQuery extends xPDOCriteria {
             $result = new xPDOQueryCondition($field);
         }
         else {
-            $result= new xPDOQueryCondition([
+            $result = new xPDOQueryCondition([
                 'sql' => $conditions,
                 'binding' => null,
                 'conjunction' => $conjunction

--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -817,6 +817,13 @@ abstract class xPDOQuery extends xPDOCriteria {
             $field['conjunction']= $conjunction;
             $result = new xPDOQueryCondition($field);
         }
+        else {
+            $result= new xPDOQueryCondition([
+                'sql' => $conditions,
+                'binding' => null,
+                'conjunction' => $conjunction
+            ]);
+        }
         return $result;
     }
 

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -1056,6 +1056,7 @@ class xPDO {
      */
     public function getObjectGraph($className, $graph, $criteria= null, $cacheFlag= true) {
         $object= null;
+        $this->sanitizePKCriteria($className, $criteria);
         if ($collection= $this->getCollectionGraph($className, $graph, $criteria, $cacheFlag)) {
             if (!count($collection) === 1) {
                 $this->log(xPDO::LOG_LEVEL_WARN, 'getObjectGraph criteria returned more than one instance.');

--- a/test/xPDO/Test/Om/xPDOObjectTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectTest.php
@@ -11,6 +11,7 @@
 namespace xPDO\Test\Om;
 
 use xPDO\Om\xPDOObject;
+use xPDO\Test\Sample\Person;
 use xPDO\TestCase;
 use xPDO\xPDO;
 
@@ -327,6 +328,13 @@ class xPDOObjectTest extends TestCase
         $person->remove();
     }
 
+    public function testGetObjectDoesNotReturnUnexpectedResults()
+    {
+        $person = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', 'test');
+
+        $this->assertNull($person, 'getObject returned an instance from an invalid key');
+    }
+
     /**
      * Test getting an object by the primary key.
      *
@@ -393,6 +401,13 @@ class xPDOObjectTest extends TestCase
         $this->assertTrue($phone instanceof \xPDO\Test\Sample\Phone, "Error retrieving related Phone object via getObjectGraph");
     }
 
+    public function testGetObjectGraphDoesNotReturnUnexpectedResults()
+    {
+        $person = $this->xpdo->getObjectGraph('xPDO\\Test\\Sample\\Person', '{"PersonPhone":{"Phone":{}}}', 'test');
+
+        $this->assertNull($person, 'getObjectGraph returned unexpected result from invalid key');
+    }
+
     /**
      * Test getObjectGraph by PK with JSON graph
      */
@@ -421,6 +436,13 @@ class xPDOObjectTest extends TestCase
         $this->assertTrue($phone instanceof \xPDO\Test\Sample\Phone, "Error retrieving related Phone object via getObjectGraph, JSON graph");
     }
 
+    public function testGetCollectionDoesNotReturnUnexpectedResults()
+    {
+        $person = $this->xpdo->getCollection('xPDO\\Test\\Sample\\Person', 'test');
+
+        $this->assertEmpty($person, 'getCollection returned data from an invalid where clause');
+    }
+
     /**
      * Test xPDO::getCollection
      */
@@ -434,6 +456,13 @@ class xPDOObjectTest extends TestCase
         $this->assertTrue(isset($people[1]) && $people[1] instanceof \xPDO\Test\Sample\Person, "Error retrieving all objects.");
         $this->assertTrue(isset($people[2]) && $people[2] instanceof \xPDO\Test\Sample\Person, "Error retrieving all objects.");
         $this->assertTrue(count($people) == 2, "Error retrieving all objects.");
+    }
+
+    public function testGetCollectionGraphDoesNotReturnUnexpectedResults()
+    {
+        $person = $this->xpdo->getCollectionGraph('xPDO\\Test\\Sample\\Person', array('PersonPhone' => array('Phone' => array())), 'test');
+
+        $this->assertEmpty($person, 'getCollectionGraph returned data from an invalid where clause');
     }
 
     /**


### PR DESCRIPTION
When passing a string condition without a conditional operator, unexpected results were being returned from `getCollection()`, `getObjectGraph()`, and `getCollectionGraph()` methods. This change makes sure the invalid where clause is still sent in the query instead of no conditions being sent which would result in all rows being returned from the query.

This patch also applies the `sanitizePKCriteria()` method to `getObjectGraph()`.