### PR TITLE
Refactor xPDO->sanitizePKCriteria to use prepared statments

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2750,20 +2750,19 @@ class xPDO {
         if (is_scalar($criteria)) {
             $pkType = $this->getPKType($className);
             if (is_string($pkType)) {
-                if (is_string($criteria) && !xPDOQuery::isValidClause($criteria)) {
-                    $criteria = null;
-                } else {
-                    switch ($pkType) {
-                        case 'int':
-                        case 'integer':
-                            $criteria = (int)$criteria;
+                $pk = $this->getPK($className);
+                switch ($pkType) {
+                    case 'int':
+                    case 'integer':
+                        if (!is_numeric($criteria)) {
+                            $criteria = null;
                             break;
-                        case 'string':
-                            if (is_int($criteria)) {
-                                $criteria = (string)$criteria;
-                            }
-                            break;
-                    }
+                        }
+                        $criteria = [$pk => (int)$criteria];
+                        break;
+                    case 'string':
+                        $criteria = [$pk => (string)$criteria];
+                        break;
                 }
             } elseif (is_array($pkType)) {
                 $criteria = null;


### PR DESCRIPTION
Refactors xPDO->sanitizePKCriteria() to convert the PK criteria directly to the array format which forces the use of prepared statements and prevents any nefarious SQL execution.

This prevents short-circuiting calls to getObject when a string primary key is involved and conditional operators are encountered in the string. The existing behavior is not only a bug, it could also potentially allow SQLi or other unwanted statements from being executed rather than being compared to the string primary key.