### PR TITLE
Prevent sleep()/benchmark() usage in xPDOQuery criteria

### DIFF
--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -101,6 +101,12 @@ abstract class xPDOQuery extends xPDOCriteria {
         $output = preg_replace('/\\".*?\\"/', '{mask}', $output);
         $output = preg_replace("/'.*?'/", '{mask}', $output);
         $output = preg_replace('/".*?"/', '{mask}', $output);
+        if (preg_match('/sleep\s*\(\s*\d+\s*\)/i', $output) > 0) {
+            return false;
+        }
+        if (preg_match('/benchmark\s*\(\s*.+,.+\s*\)/i', $output) > 0) {
+            return false;
+        }
         return strpos($output, ';') === false && strpos(strtolower($output), 'union') === false;
     }
 

--- a/test/xPDO/Test/Om/xPDOQueryTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryTest.php
@@ -549,6 +549,7 @@ class xPDOQueryTest extends TestCase {
 
         $this->assertTrue($result === null, 'xPDOQuery allowed invalid clause');
     }
+
     public function providerInvalidClauses() {
         return array(
             array("1=1;DROP TABLE `person`"),
@@ -556,6 +557,38 @@ class xPDOQueryTest extends TestCase {
             array("1=1 UNION SELECT * FROM `person` WHERE id = 2;"),
             array(array("1=1; DROP TABLE `person`;" => '')),
             array(array("1=1 UNION SELECT * FROM `person` WHERE id = 2" => '')),
+            array("1=sleep(1)"),
+            array(array("1=sleep(1)")),
+            array("1 = sleep ( 69 )"),
+            array("sleep ( 69 )"),
+            array("1=1"),
+            array("benchmark(999, 100+1)"),
+            array("if(now()=sysdate(),sleep (20),0)"),
+        );
+    }
+
+    /**
+     * @param $clause
+     * @dataProvider providerInvalidClause
+     */
+    public function testInvalidClauseReturnsFalse($clause) {
+        $this->assertFalse(xPDOQuery::isValidClause($clause));
+    }
+
+    public function providerInvalidClause() {
+        return array(
+            array("1=1;DROP TABLE `person`"),
+            array("1=1 UNION SELECT * FROM `person` WHERE id = 2"),
+            array("1=1 UNION SELECT * FROM `person` WHERE id = 2;"),
+            array("1=1; DROP TABLE `person`;"),
+            array("1=1 UNION SELECT * FROM `person` WHERE id = 2"),
+            array("1=sleep(1)"),
+            array("1 = sleep ( 69 )"),
+            array("sleep ( 69 )"),
+            array("1=benchmark(1000,1+1)"),
+            array("1 =benchmark( 999,100+1)"),
+            array("benchmark ( 999, 100+1 )"),
+            array("if(now()=sysdate(),sleep (20),0)"),
         );
     }
 }


### PR DESCRIPTION
This will not allow the use of sleep() or benchmark() functions in MySQL (as well as pg_sleep() in PostgreSQL) in any conditions or sort criteria when using xPDO criteria to build the query. This will prevent the use of these functions from being used to attempt to create any sort of denial of service or timing attack.

I can't see any real argument for needing to allow these functions in queries built with xPDOQuery. Pure SQL queries sent directly to the database via xPDO->query()/exec() or an xPDOCriteria instance could use used if this type of statement is needed.