### PR TITLE
Fix sanitizePKCriteria

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2755,8 +2755,8 @@ class xPDO {
                 switch ($pkType) {
                     case 'int':
                     case 'integer':
-                        if (!is_numeric($criteria)) {
-                            $criteria = null;
+                        if (!is_int($criteria) && (string)(int)$criteria !== (string)$criteria) {
+                            $criteria = [$pk => null];
                             break;
                         }
                         $criteria = [$pk => (int)$criteria];

--- a/test/xPDO/Test/Om/xPDOObjectTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectTest.php
@@ -328,11 +328,15 @@ class xPDOObjectTest extends TestCase
         $person->remove();
     }
 
-    public function testGetObjectDoesNotReturnUnexpectedResults()
+    /**
+     * @param $criteria
+     * @dataProvider providerInvalidIntegerPKCriteria
+     */
+    public function testGetObjectDoesNotReturnUnexpectedResults($criteria)
     {
-        $person = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', 'test');
+        $person = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', $criteria);
 
-        $this->assertNull($person, 'getObject returned an instance from an invalid key');
+        $this->assertNull($person, 'getObject returned an instance from an invalid primary key');
     }
 
     /**
@@ -401,11 +405,25 @@ class xPDOObjectTest extends TestCase
         $this->assertTrue($phone instanceof \xPDO\Test\Sample\Phone, "Error retrieving related Phone object via getObjectGraph");
     }
 
-    public function testGetObjectGraphDoesNotReturnUnexpectedResults()
+    /**
+     * @param $criteria
+     * @dataProvider providerInvalidIntegerPKCriteria
+     */
+    public function testGetObjectGraphDoesNotReturnUnexpectedResults($criteria)
     {
-        $person = $this->xpdo->getObjectGraph('xPDO\\Test\\Sample\\Person', '{"PersonPhone":{"Phone":{}}}', 'test');
+        $person = $this->xpdo->getObjectGraph('xPDO\\Test\\Sample\\Person', '{"PersonPhone":{"Phone":{}}}', $criteria);
 
-        $this->assertNull($person, 'getObjectGraph returned unexpected result from invalid key');
+        $this->assertNull($person, 'getObjectGraph returned unexpected result from invalid primary key');
+    }
+
+    public function providerInvalidIntegerPKCriteria()
+    {
+        return [
+            ['test'],
+            ['1=1'],
+            ['1.0'],
+            [1.1],
+        ];
     }
 
     /**

--- a/test/xPDO/Test/Om/xPDOQueryTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryTest.php
@@ -545,7 +545,7 @@ class xPDOQueryTest extends TestCase {
     public function testInvalidClauses($clause) {
         $criteria = $this->xpdo->newQuery('xPDO\\Test\\Sample\\Person');
         $criteria->where($clause);
-        $result = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person');
+        $result = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', $criteria);
 
         $this->assertTrue($result === null, 'xPDOQuery allowed invalid clause');
     }
@@ -561,7 +561,6 @@ class xPDOQueryTest extends TestCase {
             array(array("1=sleep(1)")),
             array("1 = sleep ( 69 )"),
             array("sleep ( 69 )"),
-            array("1=1"),
             array("benchmark(999, 100+1)"),
             array("if(now()=sysdate(),sleep (20),0)"),
         );


### PR DESCRIPTION
Make sure invalid values are sent as [pk => null].

Also fixes a unit test that was invalid and exposed additional problems with the original refactoring.