### PR TITLE
Add empty package when storing namespaced object in vehicle

### DIFF
--- a/src/xPDO/Transport/xPDOObjectVehicle.php
+++ b/src/xPDO/Transport/xPDOObjectVehicle.php
@@ -387,7 +387,7 @@ class xPDOObjectVehicle extends xPDOVehicle {
         parent :: put($transport, $object, $attributes);
         if (is_object($object)) {
             if (!isset ($this->payload['package'])) {
-                if ($object instanceof xPDOObject) {
+                if ($object instanceof xPDOObject && strpos(get_class($object), '\\') === false) {
                     $packageName = $object->_package;
                 } else {
                     $packageName = '';

--- a/src/xPDO/Transport/xPDOVehicle.php
+++ b/src/xPDO/Transport/xPDOVehicle.php
@@ -287,7 +287,7 @@ abstract class xPDOVehicle {
             $this->payload['guid'] = md5(uniqid(rand(), true));
         }
         if (!isset ($this->payload['package'])) {
-            if ($object instanceof xPDOObject) {
+            if ($object instanceof xPDOObject && strpos(get_class($object), '\\') === false) {
                 $packageName = $object->_package;
             } else {
                 $packageName = '';

--- a/test/complete.phpunit.xml
+++ b/test/complete.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
+            <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>

--- a/test/mysql.phpunit.xml
+++ b/test/mysql.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
+            <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>

--- a/test/pgsql.phpunit.xml
+++ b/test/pgsql.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
+            <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>

--- a/test/sqlite.phpunit.xml
+++ b/test/sqlite.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
+            <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>

--- a/test/xPDO/Test/Transport/xPDOVehicleTest.php
+++ b/test/xPDO/Test/Transport/xPDOVehicleTest.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * The file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Transport;
+
+
+use xPDO\Test\Sample\xPDOSample;
+use xPDO\TestCase;
+use xPDO\Transport\xPDOObjectVehicle;
+use xPDO\Transport\xPDOTransport;
+
+class xPDOVehicleTest extends TestCase
+{
+    public function testPutDoesNotAddPackageForNamespacedClass()
+    {
+        $transport = new xPDOTransport($this->xpdo, uniqid('transport-'), self::$properties['xpdo_test_path'] . 'fs/transport/');
+
+        $object = $this->xpdo->newObject(xPDOSample::class);
+
+        $vehicle = new xPDOObjectVehicle();
+        $vehicle->put($transport, $object);
+
+        $this->assertEmpty($vehicle->payload['package']);
+    }
+}


### PR DESCRIPTION
Objects stored in an xPDOVehicle from classes with a namespace should not add a package containing that namespace to the vehicle payload. Doing so causes unnecessary attempts to load classes with the namespace prefixed to the already fully-qualified classname.