### PR TITLE
update symfony/console dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-PDO": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/console": "~2.8|~3.4",
+        "symfony/console": "^4.4|^5.0",
         "psr/container": "^1.0"
     },
     "require-dev": {

--- a/src/xPDO/Console/Command/ParseSchema.php
+++ b/src/xPDO/Console/Command/ParseSchema.php
@@ -67,19 +67,19 @@ final class ParseSchema extends Command
         $platform = strtolower($input->getArgument('platform'));
         if (!in_array($platform, self::$platforms)) {
             $output->writeln("fatal: no valid platform specified");
-            return;
+            return 0;
         }
 
         $properties = $this->loadConfig($output, $input->getOption('config'));
         if ($properties === false) {
             $output->writeln('fatal: no valid configuration file could be loaded');
-            return;
+            return 0;
         }
 
         $schema = $input->getArgument('schema_file');
         if (!is_readable($schema)) {
             $output->writeln("fatal: no valid schema provided");
-            return;
+            return 0;
         }
 
         $namespacePrefix = $input->getOption('psr4');
@@ -104,5 +104,6 @@ final class ParseSchema extends Command
                 'namespacePrefix' => $namespacePrefix,
             )
         );
+        return 0;
     }
 }

--- a/src/xPDO/Console/Command/WriteSchema.php
+++ b/src/xPDO/Console/Command/WriteSchema.php
@@ -35,5 +35,6 @@ final class WriteSchema extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('write-schema command not yet implemented');
+        return 1;
     }
 }


### PR DESCRIPTION
### What does it do ?
Added `int` return codes to Symfony\Console\Command::execute() implementations.
Changed composer.json symfony/console required version.

### Why is it needed ?
Update symfony/console dependency to late versions to resolve conflicts with third-party packages.

### Related issue(s)/PR(s)
Resolves #180 