### PR TITLE
Fix deprecated warnings for 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout
@@ -114,7 +114,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,5 @@
     },
     "bin": [
         "bin/xpdo"
-    ],
-    "extra": {
-        "branch-alias": {
-            "dev-develop": "3.0.x-dev"
-        }
-    }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "symfony/console": "~2.8|~3.4",
-        "psr/container": "^1.0"
+        "psr/container": "1.0.*"
     },
     "require-dev": {
         "yoast/phpunit-polyfills": "^0.2.0"

--- a/src/xPDO/Validation/xPDOValidator.php
+++ b/src/xPDO/Validation/xPDOValidator.php
@@ -65,7 +65,11 @@ class xPDOValidator {
                                 }
                                 break;
                             case 'preg_match':
-                                $result= (boolean) preg_match($rule['rule'], $this->object->_fields[$column]);
+                                if (is_null($this->object->_fields[$column])) {
+                                    $result = false;
+                                } else {
+                                    $result = (boolean)preg_match($rule['rule'], $this->object->_fields[$column]);
+                                }
                                 if (!$result) $this->addMessage($column, $ruleName, isset($rule['parameters']['message']) ? $rule['parameters']['message'] : $ruleName . ' failed');
                                 if ($this->object->xpdo->getDebug() === true)
                                     $this->object->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "preg_match validation against {$rule['rule']} resulted in " . print_r($result, 1));

--- a/src/xPDO/xPDOContainer.php
+++ b/src/xPDO/xPDOContainer.php
@@ -11,6 +11,8 @@
 namespace xPDO;
 
 
+use ArrayAccess;
+use Exception;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -22,7 +24,7 @@ use xPDO\Exception\Container\NotFoundException;
  *
  * @package xPDO
  */
-class xPDOContainer implements ContainerInterface, \ArrayAccess
+class xPDOContainer implements ContainerInterface, ArrayAccess
 {
     private $entries = array();
 
@@ -52,7 +54,7 @@ class xPDOContainer implements ContainerInterface, \ArrayAccess
         if ($this->has($id)) {
             try {
                 return $this->offsetGet($id);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 throw new ContainerException($e->getMessage(), $e->getCode(), $e);
             }
         }
@@ -65,82 +67,32 @@ class xPDOContainer implements ContainerInterface, \ArrayAccess
      *
      * @param string $id Identifier of the entry to look for.
      *
-     * @return boolean
+     * @return bool
      */
     public function has($id)
     {
         return $this->offsetExists($id);
     }
 
-    /**
-     * Whether a offset exists
-     *
-     * @link  http://php.net/manual/en/arrayaccess.offsetexists.php
-     *
-     * @param mixed $offset <p>
-     *                      An offset to check for.
-     *                      </p>
-     *
-     * @return boolean true on success or false on failure.
-     * </p>
-     * <p>
-     * The return value will be casted to boolean if non-boolean was returned.
-     * @since 5.0.0
-     */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->entries);
     }
 
-    /**
-     * Offset to retrieve
-     *
-     * @link  http://php.net/manual/en/arrayaccess.offsetget.php
-     *
-     * @param mixed $offset <p>
-     *                      The offset to retrieve.
-     *                      </p>
-     *
-     * @return mixed Can return all value types.
-     * @since 5.0.0
-     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->entries[$offset];
     }
 
-    /**
-     * Offset to set
-     *
-     * @link  http://php.net/manual/en/arrayaccess.offsetset.php
-     *
-     * @param mixed $offset <p>
-     *                      The offset to assign the value to.
-     *                      </p>
-     * @param mixed $value  <p>
-     *                      The value to set.
-     *                      </p>
-     *
-     * @return void
-     * @since 5.0.0
-     */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->entries[$offset] = $value;
     }
 
-    /**
-     * Offset to unset
-     *
-     * @link  http://php.net/manual/en/arrayaccess.offsetunset.php
-     *
-     * @param mixed $offset <p>
-     *                      The offset to unset.
-     *                      </p>
-     *
-     * @return void
-     * @since 5.0.0
-     */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->entries[$offset]);

--- a/src/xPDO/xPDOIterator.php
+++ b/src/xPDO/xPDOIterator.php
@@ -113,6 +113,7 @@ class xPDOIterator implements Iterator {
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function valid() {
         return ($this->current !== null);
     }

--- a/src/xPDO/xPDOIterator.php
+++ b/src/xPDO/xPDOIterator.php
@@ -11,6 +11,9 @@
 namespace xPDO;
 
 
+use Iterator;
+use PDOStatement;
+
 /**
  * An iterable representation of an xPDOObject result set.
  *
@@ -20,11 +23,11 @@ namespace xPDO;
  *
  * @package xpdo
  */
-class xPDOIterator implements \Iterator {
+class xPDOIterator implements Iterator {
     private $xpdo = null;
     private $index = 0;
     private $current = null;
-    /** @var null|\PDOStatement */
+    /** @var null|PDOStatement */
     private $stmt = null;
     private $class = null;
     private $alias = null;
@@ -39,7 +42,6 @@ class xPDOIterator implements \Iterator {
      * @see xPDO::getIterator()
      * @param xPDO &$xpdo A reference to a valid xPDO instance.
      * @param array $options An array of options for the iterator.
-     * @return xPDOIterator An xPDOIterator instance.
      */
     function __construct(& $xpdo, array $options= array()) {
         $this->xpdo =& $xpdo;
@@ -69,7 +71,9 @@ class xPDOIterator implements \Iterator {
         }
     }
 
-    public function rewind() {
+    #[\ReturnTypeWillChange]
+    public function rewind()
+    {
         $this->index = 0;
         if (!empty($this->stmt)) {
             $this->stmt->closeCursor();
@@ -86,22 +90,27 @@ class xPDOIterator implements \Iterator {
         }
     }
 
-    public function current() {
+    #[\ReturnTypeWillChange]
+    public function current()
+    {
         return $this->current;
     }
 
-    public function key() {
+    #[\ReturnTypeWillChange]
+    public function key()
+    {
         return $this->index;
     }
 
-    public function next() {
+    #[\ReturnTypeWillChange]
+    public function next()
+    {
         $this->fetch();
         if (!$this->valid()) {
             $this->index = null;
         } else {
             $this->index++;
         }
-        return $this->current();
     }
 
     public function valid() {

--- a/src/xPDO/xPDOMap.php
+++ b/src/xPDO/xPDOMap.php
@@ -11,7 +11,9 @@
 namespace xPDO;
 
 
-class xPDOMap implements \ArrayAccess
+use ArrayAccess;
+
+class xPDOMap implements ArrayAccess
 {
     /**
      * @var array An object/relational map by class.
@@ -45,12 +47,14 @@ class xPDOMap implements \ArrayAccess
         return $this->map[$offset];
     }
 
-    public function offsetSet($offset, $value): void
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
     {
         $this->map[$offset] = $value;
     }
 
-    public function offsetUnset($offset): void
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
     {
         unset($this->map[$offset]);
     }

--- a/src/xPDO/xPDOMap.php
+++ b/src/xPDO/xPDOMap.php
@@ -36,6 +36,7 @@ class xPDOMap implements \ArrayAccess
         return isset($this->map[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!isset($this->map[$offset])) {
@@ -44,12 +45,12 @@ class xPDOMap implements \ArrayAccess
         return $this->map[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->map[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->map[$offset]);
     }


### PR DESCRIPTION
These fixes are for 3.0.x to maintain support back to 5.6 for early 3.x adopters.