### PR TITLE
Improve PHP 8.1 compatibility

### DIFF
--- a/xpdo/om/xpdoobject.class.php
+++ b/xpdo/om/xpdoobject.class.php
@@ -838,7 +838,7 @@ class xPDOObject {
                                                 $ts= strtotime($v);
                                             }
                                             if ($ts !== false) {
-                                                $this->_fields[$k]= strftime('%Y-%m-%d %H:%M:%S', $ts);
+                                                $this->_fields[$k]= date('Y-m-d H:i:s', $ts);
                                                 $set= true;
                                             }
                                         }
@@ -868,7 +868,7 @@ class xPDOObject {
                                             }
                                             $ts= strtotime($v);
                                             if ($ts !== false) {
-                                                $this->_fields[$k]= strftime('%Y-%m-%d', $ts);
+                                                $this->_fields[$k]= date('Y-m-d H:i:s', $ts);
                                                 $set= true;
                                             }
                                         }
@@ -1027,7 +1027,7 @@ class xPDOObject {
                                         $value= strftime($format, $ts);
                                     }
                                 } else {
-                                    $value= strftime('%Y-%m-%d %H:%M:%S', $ts);
+                                    $value= date('Y-m-d H:i:s', $ts);
                                 }
                             }
                             break;
@@ -1042,7 +1042,7 @@ class xPDOObject {
                             if ($ts !== false && !empty($value)) {
                                 if (is_string($format) && !empty ($format)) {
                                     if (strpos($format, 're:') === 0) {
-                                        $value= strftime('%Y-%m-%d', $ts);
+                                        $value= date('Y-m-d', $ts);
                                         if (!empty ($formatTemplate) && is_string($formatTemplate)) {
                                             $value= preg_replace(substr($format, 3), $formatTemplate, $value);
                                         }
@@ -1052,7 +1052,7 @@ class xPDOObject {
                                         $value= strftime($format, $ts);
                                     }
                                 } else {
-                                    $value= strftime('%Y-%m-%d', $ts);
+                                    $value= date('Y-m-d', $ts);
                                 }
                             }
                             break;
@@ -1371,7 +1371,7 @@ class xPDOObject {
                 $fieldType= PDO::PARAM_STR;
                 $fieldValue= $this->_fields[$_k];
                 if (in_array($this->_fieldMeta[$_k]['phptype'], array ('datetime', 'timestamp')) && !empty($this->_fieldMeta[$_k]['attributes']) && $this->_fieldMeta[$_k]['attributes'] == 'ON UPDATE CURRENT_TIMESTAMP') {
-                    $this->_fields[$_k]= strftime('%Y-%m-%d %H:%M:%S');
+                    $this->_fields[$_k]= date('Y-m-d H:i:s');
                     continue;
                 }
                 elseif ($fieldValue === null || $fieldValue === 'NULL') {
@@ -1380,11 +1380,11 @@ class xPDOObject {
                     $fieldValue= null;
                 }
                 elseif (in_array($this->_fieldMeta[$_k]['phptype'], array ('timestamp', 'datetime')) && in_array($fieldValue, $this->xpdo->driver->_currentTimestamps, true)) {
-                    $this->_fields[$_k]= strftime('%Y-%m-%d %H:%M:%S');
+                    $this->_fields[$_k]= date('Y-m-d H:i:s');
                     continue;
                 }
                 elseif (in_array($this->_fieldMeta[$_k]['phptype'], array ('date')) && in_array($fieldValue, $this->xpdo->driver->_currentDates, true)) {
-                    $this->_fields[$_k]= strftime('%Y-%m-%d');
+                    $this->_fields[$_k]= date('Y-m-d');
                     continue;
                 }
                 elseif ($this->_fieldMeta[$_k]['phptype'] == 'timestamp' && preg_match('/int/i', $this->_fieldMeta[$_k]['dbtype'])) {

--- a/xpdo/validation/xpdovalidator.class.php
+++ b/xpdo/validation/xpdovalidator.class.php
@@ -79,7 +79,9 @@ class xPDOValidator {
                                 }
                                 break;
                             case 'preg_match':
-                                $result= (boolean) preg_match($rule['rule'], $this->object->_fields[$column]);
+                                if (is_string($this->object->_fields[$column])) {
+                                    $result = (boolean)preg_match($rule['rule'], $this->object->_fields[$column]);
+                                }
                                 if (!$result) $this->addMessage($column, $ruleName, isset($rule['parameters']['message']) ? $rule['parameters']['message'] : $ruleName . ' failed');
                                 if ($this->object->xpdo->getDebug() === true)
                                     $this->object->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "preg_match validation against {$rule['rule']} resulted in " . print_r($result, 1));

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -2055,7 +2055,7 @@ class xPDO {
         }
         if ($level === xPDO::LOG_LEVEL_FATAL) {
             while (ob_get_level() && @ob_end_flush()) {}
-            exit ('[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''));
+            exit ('[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''));
         }
         @ob_start();
         if (!empty ($def)) {
@@ -2069,10 +2069,10 @@ class xPDO {
         }
         switch ($target) {
             case 'HTML' :
-                echo '<h5>[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ')</h5><pre>' . $msg . '</pre>' . "\n";
+                echo '<h5>[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ')</h5><pre>' . $msg . '</pre>' . "\n";
                 break;
             default :
-                echo '[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n";
+                echo '[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n";
         }
         $content= @ob_get_contents();
         @ob_end_clean();

--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -2981,6 +2981,7 @@ class xPDOIterator implements Iterator {
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind() {
         $this->index = 0;
         if (!empty($this->stmt)) {
@@ -2998,14 +2999,17 @@ class xPDOIterator implements Iterator {
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function current() {
         return $this->current;
     }
 
+    #[\ReturnTypeWillChange]
     public function key() {
         return $this->index;
     }
 
+    #[\ReturnTypeWillChange]
     public function next() {
         $this->fetch();
         if (!$this->valid()) {
@@ -3016,6 +3020,7 @@ class xPDOIterator implements Iterator {
         return $this->current();
     }
 
+    #[\ReturnTypeWillChange]
     public function valid() {
         return ($this->current !== null);
     }


### PR DESCRIPTION
Improves PHP 8.1 compatibility by removing unnecessary `strftime()` calls and adding the `#[\ReturnTypeWillChange]` attribute to mute return type deprecation warnings from core functions.