### PR TITLE
Update symfony/console version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-PDO": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/console": "~2.8|~3.4",
+        "symfony/console": "~2.8|~3.4|~4.4|~5.4",
         "psr/container": "1.0.*"
     },
     "require-dev": {


### PR DESCRIPTION
This will allow the use of xPDO 3.0.x in places where symfony console must be newer