### PR TITLE
Fix passing null to int param is deprecated

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -1100,7 +1100,7 @@ class xPDO {
             if ($stmt->execute()) {
                 $this->queryTime += microtime(true) - $tstart;
                 $this->executedQueries++;
-                $value= $stmt->fetchColumn($column);
+                $value= $stmt->fetchColumn((int)$column);
                 $stmt->closeCursor();
             } else {
                 $this->queryTime += microtime(true) - $tstart;


### PR DESCRIPTION
Prevent "PDOStatement::fetchColumn(): Passing null to parameter #1 ($column) of type int is deprecated" warning in getValue() when not specifying a column.