### PR TITLE
Implement generics syntax to allow improved static analysis

### DIFF
--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -275,11 +275,12 @@ class xPDOObject {
      * Loads an instance from an associative array.
      *
      * @static
+     * @template T of xPDOObject
      * @param xPDO &$xpdo A valid xPDO instance.
-     * @param string $className Name of the class.
+     * @param class-string<T> $className Name of the class.
      * @param xPDOQuery|string $criteria A valid xPDOQuery instance or relation alias.
      * @param array $row The associative array containing the instance data.
-     * @return xPDOObject A new xPDOObject derivative representing a data row.
+     * @return T|null A new xPDOObject derivative representing a data row.
      */
     public static function _loadInstance(& $xpdo, $className, $criteria, $row) {
         $rowPrefix= '';
@@ -342,9 +343,10 @@ class xPDOObject {
      * Responsible for loading an instance into a collection.
      *
      * @static
+     * @template T of xPDOObject
      * @param xPDO &$xpdo A valid xPDO instance.
      * @param array &$objCollection The collection to load the instance into.
-     * @param string $className Name of the class.
+     * @param class-string<T> $className Name of the class.
      * @param mixed $criteria A valid primary key, criteria array, or xPDOCriteria instance.
      * @param array $row The associative array containing the instance data.
      * @param bool $fromCache If the instance is for the cache
@@ -384,13 +386,14 @@ class xPDOObject {
      * Load an instance of an xPDOObject or derivative class.
      *
      * @static
+     * @template T of xPDOObject
      * @param xPDO &$xpdo A valid xPDO instance.
-     * @param string $className Name of the class.
+     * @param class-string<T> $className Name of the class.
      * @param mixed $criteria A valid primary key, criteria array, or
      * xPDOCriteria instance.
      * @param bool|int $cacheFlag Indicates if the objects should be cached and
      * optionally, by specifying an integer value, for how many seconds.
-     * @return object|null An instance of the requested class, or null if it
+     * @return T|null An instance of the requested class, or null if it
      * could not be instantiated.
      */
     public static function load(xPDO & $xpdo, $className, $criteria, $cacheFlag= true) {
@@ -442,13 +445,14 @@ class xPDOObject {
      * Load a collection of xPDOObject instances.
      *
      * @static
+     * @template T of xPDOObject
      * @param xPDO &$xpdo A valid xPDO instance.
-     * @param string $className Name of the class.
+     * @param class-string<T> $className Name of the class.
      * @param mixed $criteria A valid primary key, criteria array, or xPDOCriteria instance.
      * @param boolean|integer $cacheFlag Indicates if the objects should be
      * cached and optionally, by specifying an integer value, for how many
      * seconds.
-     * @return array An array of xPDOObject instances or an empty array if no instances are loaded.
+     * @return array<int, T> An array of xPDOObject instances or an empty array if no instances are loaded.
      */
     public static function loadCollection(xPDO & $xpdo, $className, $criteria= null, $cacheFlag= true) {
         $objCollection= array ();
@@ -492,8 +496,9 @@ class xPDOObject {
      * Load a collection of xPDOObject instances and a graph of related objects.
      *
      * @static
+     * @template T of xPDOObject
      * @param xPDO &$xpdo A valid xPDO instance.
-     * @param string $className Name of the class.
+     * @param class-string<T> $className Name of the class.
      * @param string|array $graph A related object graph in array or JSON
      * format, e.g. array('relationAlias'=>array('subRelationAlias'=>array()))
      * or {"relationAlias":{"subRelationAlias":{}}}.  Note that the empty arrays
@@ -502,7 +507,7 @@ class xPDOObject {
      * @param boolean|integer $cacheFlag Indicates if the objects should be
      * cached and optionally, by specifying an integer value, for how many
      * seconds.
-     * @return array An array of xPDOObject instances or an empty array if no instances are loaded.
+     * @return array<int, T> An array of xPDOObject instances or an empty array if no instances are loaded.
      */
     public static function loadCollectionGraph(xPDO & $xpdo, $className, $graph, $criteria, $cacheFlag) {
         $objCollection = array();
@@ -609,7 +614,6 @@ class xPDOObject {
      *
      * @access public
      * @param xPDO &$xpdo A reference to a valid xPDO instance.
-     * @return xPDOObject
      */
     public function __construct(xPDO & $xpdo) {
         $this->xpdo= & $xpdo;

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -856,7 +856,7 @@ class xPDO {
      * the time to live in the result set cache; if cacheFlag === false, caching
      * is ignored for the collection and if cacheFlag === true, the objects will
      * live in cache until flushed by another process.
-     * @return array<int, T>|null An array of class instances retrieved.
+     * @return array<int, T> An array of class instances retrieved.
     */
     public function getCollection($className, $criteria= null, $cacheFlag= true) {
         return $this->call($className, 'loadCollection', array(& $this, $className, $criteria, $cacheFlag));
@@ -1046,7 +1046,8 @@ class xPDO {
      * Retrieves an xPDOObject instance with specified related objects.
      *
      * @uses xPDO::getCollectionGraph()
-     * @param string $className The name of the class to return an instance of.
+     * @template T of xPDOObject
+     * @param class-string<T> $className The name of the class to return an instance of.
      * @param string|array $graph A related object graph in array or JSON
      * format, e.g. array('relationAlias'=>array('subRelationAlias'=>array()))
      * or {"relationAlias":{"subRelationAlias":{}}}.  Note that the empty arrays
@@ -1054,7 +1055,7 @@ class xPDO {
      * @param mixed $criteria A valid xPDOCriteria instance or expression.
      * @param boolean|integer $cacheFlag Indicates if the result set should be
      * cached, and optionally for how many seconds.
-     * @return Om\xPDOObject|null The object instance with related objects from the graph
+     * @return T|null The object instance with related objects from the graph
      * hydrated, or null if no instance can be located by the criteria.
      */
     public function getObjectGraph($className, $graph, $criteria= null, $cacheFlag= true) {
@@ -1073,14 +1074,15 @@ class xPDO {
      * Retrieves a collection of xPDOObject instances with related objects.
      *
      * @uses xPDOQuery::bindGraph()
-     * @param string $className The name of the class to return a collection of.
+     * @template T of xPDOObject
+     * @param class-string<T> $className The name of the class to return a collection of.
      * @param string|array $graph A related object graph in array or JSON
      * format, e.g. array('relationAlias'=>array('subRelationAlias'=>array()))
      * or {"relationAlias":{"subRelationAlias":{}}}.  Note that the empty arrays
      * are necessary in order for the relation to be recognized.
      * @param mixed $criteria A valid xPDOCriteria instance or condition string.
      * @param boolean $cacheFlag Indicates if the result set should be cached.
-     * @return array An array of instances matching the criteria with related
+     * @return array<int, T> An array of instances matching the criteria with related
      * objects from the graph hydrated.  An empty array is returned when no
      * matches are found.
      */

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -793,9 +793,9 @@ class xPDO {
      *
      * All new objects created with this method are transient until {@link
      * xPDOObject::save()} is called the first time and is reflected by the
-     * {@link xPDOObject::$_new} property.
+     * {@link Om\xPDOObject::$_new} property.
      *
-     * @template T of xPDOObject
+     * @template T of Om\xPDOObject
      * @param class-string<T> $className Name of the class to get a new instance of.
      * @param array $fields An associated array of field names/values to
      * populate the object with.
@@ -825,7 +825,7 @@ class xPDO {
      * cannot be located by the supplied criteria, null is returned.
      *
      * @uses xPDOObject::load()
-     * @template T of xPDOObject
+     * @template T of Om\xPDOObject
      * @param class-string<T> $className Name of the class to get an instance of.
      * @param mixed $criteria Primary key of the record or a xPDOCriteria object.
      * @param mixed $cacheFlag If an integer value is provided, this specifies
@@ -848,7 +848,7 @@ class xPDO {
      * Retrieves a collection of xPDOObjects by the specified xPDOCriteria.
      *
      * @uses xPDOObject::loadCollection()
-     * @template T of xPDOObject
+     * @template T of Om\xPDOObject
      * @param class-string<T> $className Name of the class to search for instances of.
      * @param object|array|string $criteria An xPDOCriteria object or an array
      * search expression.
@@ -1046,7 +1046,7 @@ class xPDO {
      * Retrieves an xPDOObject instance with specified related objects.
      *
      * @uses xPDO::getCollectionGraph()
-     * @template T of xPDOObject
+     * @template T of Om\xPDOObject
      * @param class-string<T> $className The name of the class to return an instance of.
      * @param string|array $graph A related object graph in array or JSON
      * format, e.g. array('relationAlias'=>array('subRelationAlias'=>array()))
@@ -1074,7 +1074,7 @@ class xPDO {
      * Retrieves a collection of xPDOObject instances with related objects.
      *
      * @uses xPDOQuery::bindGraph()
-     * @template T of xPDOObject
+     * @template T of Om\xPDOObject
      * @param class-string<T> $className The name of the class to return a collection of.
      * @param string|array $graph A related object graph in array or JSON
      * format, e.g. array('relationAlias'=>array('subRelationAlias'=>array()))

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -795,10 +795,11 @@ class xPDO {
      * xPDOObject::save()} is called the first time and is reflected by the
      * {@link xPDOObject::$_new} property.
      *
-     * @param string $className Name of the class to get a new instance of.
+     * @template T of xPDOObject
+     * @param class-string<T> $className Name of the class to get a new instance of.
      * @param array $fields An associated array of field names/values to
      * populate the object with.
-     * @return Om\xPDOObject|null A new instance of the specified class, or null if a
+     * @return T|null A new instance of the specified class, or null if a
      * new object could not be instantiated.
      */
     public function newObject($className, $fields= array ()) {
@@ -824,13 +825,14 @@ class xPDO {
      * cannot be located by the supplied criteria, null is returned.
      *
      * @uses xPDOObject::load()
-     * @param string $className Name of the class to get an instance of.
+     * @template T of xPDOObject
+     * @param class-string<T> $className Name of the class to get an instance of.
      * @param mixed $criteria Primary key of the record or a xPDOCriteria object.
      * @param mixed $cacheFlag If an integer value is provided, this specifies
      * the time to live in the object cache; if cacheFlag === false, caching is
      * ignored for the object and if cacheFlag === true, the object will live in
      * cache indefinitely.
-     * @return Om\xPDOObject|null An instance of the class, or null if it could not be
+     * @return T|null An instance of the class, or null if it could not be
      * instantiated.
     */
     public function getObject($className, $criteria= null, $cacheFlag= true) {
@@ -846,14 +848,15 @@ class xPDO {
      * Retrieves a collection of xPDOObjects by the specified xPDOCriteria.
      *
      * @uses xPDOObject::loadCollection()
-     * @param string $className Name of the class to search for instances of.
+     * @template T of xPDOObject
+     * @param class-string<T> $className Name of the class to search for instances of.
      * @param object|array|string $criteria An xPDOCriteria object or an array
      * search expression.
      * @param mixed $cacheFlag If an integer value is provided, this specifies
      * the time to live in the result set cache; if cacheFlag === false, caching
      * is ignored for the collection and if cacheFlag === true, the objects will
      * live in cache until flushed by another process.
-     * @return array|null An array of class instances retrieved.
+     * @return array<int, T>|null An array of class instances retrieved.
     */
     public function getCollection($className, $criteria= null, $cacheFlag= true) {
         return $this->call($className, 'loadCollection', array(& $this, $className, $criteria, $cacheFlag));


### PR DESCRIPTION
I've been playing with phpstan the last few days and because xPDO is everywhere, this is something I've been running into. getObject()/getCollection() etc returning an xPDOObject is not specific enough.

These docblock changes allow phpstan to better infer types because it'll recognise it either gets an instance of the $className or null. 

PHPStorm also understands the syntax:

![Scherm­afbeelding 2022-12-11 om 01 52 47](https://user-images.githubusercontent.com/312944/206881355-e83f604c-21ef-4d00-a620-018466a7b654.jpg)


More details:

- https://phpstan.org/blog/generics-in-php-using-phpdocs
- https://phpstan.org/blog/generics-by-examples
