### PR TITLE
Add public xpdo property to xPDOCriteria

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -2776,6 +2776,7 @@ class xPDO {
  *
  */
 class xPDOCriteria {
+    public $xpdo= null;
     public $sql= '';
     public $stmt= null;
     public $bindings= array ();


### PR DESCRIPTION
The xPDOCriteria dynamically assigns a value to an xpdo property in the constructor, which is deprecated in PHP 8.2. Adding the public property avoids the deprecation warning.

Resolves #239