### PR TITLE
Add public xpdo property to xPDOCriteria

### DIFF
--- a/src/xPDO/Om/xPDOCriteria.php
+++ b/src/xPDO/Om/xPDOCriteria.php
@@ -18,6 +18,7 @@ use xPDO\xPDO;
  * @package xPDO\Om
  */
 class xPDOCriteria {
+    public $xpdo= null;
     public $sql= '';
     public $stmt= null;
     public $bindings= array ();


### PR DESCRIPTION
The xPDOCriteria dynamically assigns a value to an xpdo property in the constructor, which is deprecated in PHP 8.2. Adding the public property avoids the deprecation warning.

Resolves #239