### PR TITLE
Force query operator to the uppercase

### DIFF
--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -730,12 +730,12 @@ abstract class xPDOQuery extends xPDOCriteria {
                         $key_operator= explode(':', $key);
                         if ($key_operator && count($key_operator) === 2) {
                             $key= $key_operator[0];
-                            $operator= $key_operator[1];
+                            $operator= strtoupper($key_operator[1]);
                         }
                         elseif ($key_operator && count($key_operator) === 3) {
                             $conj= $key_operator[0];
                             $key= $key_operator[1];
-                            $operator= $key_operator[2];
+                            $operator= strtoupper($key_operator[2]);
                         }
                         if (strpos($key, '.') !== false) {
                             $key_parts= explode('.', $key);
@@ -762,7 +762,7 @@ abstract class xPDOQuery extends xPDOCriteria {
                             else {
                                 $type= \PDO::PARAM_STR;
                             }
-                            if (in_array(strtoupper($operator), array('IN', 'NOT IN')) && is_array($val)) {
+                            if (in_array($operator, array('IN', 'NOT IN')) && is_array($val)) {
                                 $vals = array();
                                 foreach ($val as $v) {
                                     if ($v === null) {


### PR DESCRIPTION
Fix using lowercased operators like `is not`.