### PR TITLE
Add AllowDynamicProperties attribute to xPDO class

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -55,6 +55,7 @@ if (!defined('XPDO_CLI_MODE')) {
  *
  * @package xpdo
  */
+#[\AllowDynamicProperties]
 class xPDO {
     /**#@+
      * Constants


### PR DESCRIPTION
This will avoid any compatibility issues with PHP >= 8.2 when using the deprecated getService() method in legacy applications.