### PR TITLE
Fatal error on pclzip

### DIFF
--- a/xpdo/compression/pclzip.lib.php
+++ b/xpdo/compression/pclzip.lib.php
@@ -2643,7 +2643,12 @@
     if ($p_header['stored_filename'] == "") {
       $p_header['status'] = "filtered";
     }
-    
+
+    // ----- Look for empty size
+    if (!($p_header['size'] > 0)) {
+      $p_header['status'] = "filtered";
+    }
+
     // ----- Check the path length
     if (strlen($p_header['stored_filename']) > 0xFF) {
       $p_header['status'] = 'filename_too_long';


### PR DESCRIPTION
If the size returns null or 0 the script fails with a fatal error at fread. 