### PR TITLE
Add AllowDynamicProperties attribute to xPDO class

### DIFF
--- a/xpdo/xpdo.class.php
+++ b/xpdo/xpdo.class.php
@@ -88,6 +88,7 @@ if (!class_exists('PDO')) {
  *
  * @package xpdo
  */
+#[\AllowDynamicProperties]
 class xPDO {
     /**#@+
      * Constants


### PR DESCRIPTION
This avoids the deprecation warning when dynamic properties are assigned to the class in 8.2+ and resolves #256 