### PR TITLE
Remove realpath to enable xPDO usage in PHARs

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOCriteria;
 use xPDO\Om\xPDOQuery;
 
 if (!defined('XPDO_CORE_PATH')) {
-    $xpdo_core_path= strtr(realpath(dirname(__FILE__)), '\\', '/') . '/';
+    $xpdo_core_path= strtr(dirname(__FILE__), '\\', '/') . '/';
     /**
      * @var string The full path to the xPDO root directory.
      */


### PR DESCRIPTION
The use of realpath in the xPDO class to define XPDO_CORE_PATH breaks xPDO usage when included in a PHAR archive.