### PR TITLE
Run validators only for root object in xPDOObjectVehicle install

### DIFF
--- a/src/xPDO/Transport/xPDOObjectVehicle.php
+++ b/src/xPDO/Transport/xPDOObjectVehicle.php
@@ -139,7 +139,7 @@ class xPDOObjectVehicle extends xPDOVehicle {
             if (!empty ($vOptions[xPDOTransport::PREEXISTING_MODE])) {
                 $preExistingMode = intval($vOptions[xPDOTransport::PREEXISTING_MODE]);
             }
-            if ($this->validate($transport, $object, $vOptions)) {
+            if ($parentObject !== null || $this->validate($transport, $object, $vOptions)) {
                 if (!$this->_installRelated($transport, $object, $element, $options, 'foreign')) {
                     $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not install related objects with foreign owned keys for vehicle object of class {$vClass}; criteria: " . print_r($criteria, true));
                     if ($transport->xpdo->getDebug() === true) $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, 'Could not install related objects for vehicle: ' . print_r($vOptions, true));


### PR DESCRIPTION
### What does it do?
In `xPDOObjectVehicle::_installObject()`, validation is now run only when installing the root object (`$parentObject === null`). For related objects (`$parentObject !== null`), validation is skipped since validators are vehicle-level and already executed for the root.

Change: `if ($parentObject !== null || $this->validate($transport, $object, $vOptions))`

### Why is it needed?
Vehicle validators were invoked for every `_installObject()` call—once for the root and once per related object (e.g. Plugin + 2 PluginEvents = 3 times). The same validator script ran repeatedly, causing duplicate messages and unnecessary work.

### How to test
1. Build a package with one vehicle and one PHP validator (e.g. Captcha package).
2. Install or reinstall the package in Manager (Workspace → Packages).
3. Expected: validator message appears **once** in the log/console.
4. Verify that installation still blocks when the validator returns `false`.

### Related issue(s)/PR(s)
Resolves https://github.com/modxcms/revolution/issues/16223