### PR TITLE
fix(core): addPackage returns result of setPackageMeta when adding/updating package

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -494,9 +494,10 @@ class xPDO {
                 $prefix= !is_string($prefix) ? $this->config[xPDO::OPT_TABLE_PREFIX] : $prefix;
                 if (!array_key_exists($pkg, $this->packages) || $this->packages[$pkg]['path'] !== $path || $this->packages[$pkg]['prefix'] !== $prefix) {
                     $this->packages[$pkg]= array('path' => $path, 'prefix' => $prefix);
-                    $this->setPackageMeta($pkg, $path, $namespacePrefix);
+                    $added = $this->setPackageMeta($pkg, $path, $namespacePrefix);
+                } else {
+                    $added = true;
                 }
-                $added= true;
             }
         } else {
             $this->log(xPDO::LOG_LEVEL_ERROR, 'addPackage called with an invalid package name.');


### PR DESCRIPTION
addPackage() now returns the result of setPackageMeta() when adding or updating a package, so callers get false when metadata load fails (e.g. missing or empty metadata.\{dbtype}.php). When the package is already loaded with the same path/prefix, addPackage() still returns true.

Previously addPackage() always set $added = true after calling setPackageMeta(), so callers could not detect metadata load failure. setPackage() already relies on addPackage()'s return value to avoid changing the current package on failure.

We assign $added from the single setPackageMeta() call in the new/updated branch and use else { $added = true } when the package is already registered with the same path/prefix, so setPackageMeta() is not called twice.

Fixes https://github.com/modxcms/xpdo/issues/145