### PR TITLE
fix(xpdo): Fix Illegal offset type for compound PK with generated field (#129)

### DIFF
--- a/src/xPDO/Om/mysql/xPDOManager.php
+++ b/src/xPDO/Om/mysql/xPDOManager.php
@@ -416,8 +416,28 @@ class xPDOManager extends \xPDO\Om\xPDOManager {
         $notNull= !isset ($meta['null']) ? false : ($meta['null'] === 'false' || empty($meta['null']));
         $null= $notNull ? ' NOT NULL' : ' NULL';
         $extra= '';
-        if (isset($meta['index']) && $meta['index'] == 'pk' && !is_array($pk) && $pktype == 'integer' && isset ($meta['generated']) && $meta['generated'] == 'native') {
-            $extra= ' AUTO_INCREMENT';
+        $isGeneratedPkField = isset($meta['index']) && $meta['index'] == 'pk'
+            && isset($meta['generated']) && $meta['generated'] == 'native'
+            && (isset($meta['phptype']) ? $meta['phptype'] : '') === 'integer';
+        if ($isGeneratedPkField) {
+            if (!is_array($pk)) {
+                $extra = ' AUTO_INCREMENT';
+            } else {
+                $firstPkColumn = null;
+                $indexes = $this->xpdo->getIndexMeta($class);
+                if (is_array($indexes)) {
+                    foreach ($indexes as $idx) {
+                        if (!empty($idx['primary']) && isset($idx['columns']) && is_array($idx['columns'])) {
+                            $cols = array_keys($idx['columns']);
+                            $firstPkColumn = $cols[0] ?? null;
+                            break;
+                        }
+                    }
+                }
+                if ($firstPkColumn === $name) {
+                    $extra = ' AUTO_INCREMENT';
+                }
+            }
         }
         if (empty ($extra) && isset ($meta['extra'])) {
             $extra= ' ' . $meta['extra'];

--- a/src/xPDO/Om/mysql/xPDOManager.php
+++ b/src/xPDO/Om/mysql/xPDOManager.php
@@ -417,24 +417,14 @@ class xPDOManager extends \xPDO\Om\xPDOManager {
         $null= $notNull ? ' NOT NULL' : ' NULL';
         $extra= '';
         $isGeneratedPkField = isset($meta['index']) && $meta['index'] == 'pk'
-            && isset($meta['generated']) && $meta['generated'] == 'native'
-            && (isset($meta['phptype']) ? $meta['phptype'] : '') === 'integer';
-        if ($isGeneratedPkField) {
+            && isset($meta['generated']) && $meta['generated'] == 'native';
+        if ($isGeneratedPkField && ($meta['phptype'] ?? '') === 'integer') {
             if (!is_array($pk)) {
                 $extra = ' AUTO_INCREMENT';
             } else {
-                $firstPkColumn = null;
-                $indexes = $this->xpdo->getIndexMeta($class);
-                if (is_array($indexes)) {
-                    foreach ($indexes as $idx) {
-                        if (!empty($idx['primary']) && isset($idx['columns']) && is_array($idx['columns'])) {
-                            $cols = array_keys($idx['columns']);
-                            $firstPkColumn = $cols[0] ?? null;
-                            break;
-                        }
-                    }
-                }
-                if ($firstPkColumn === $name) {
+                $primaryColumns = $this->xpdo->getIndexMeta($class)['PRIMARY']['columns'] ?? [];
+                reset($primaryColumns);
+                if (key($primaryColumns) === $name) {
                     $extra = ' AUTO_INCREMENT';
                 }
             }

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -1470,15 +1470,17 @@ class xPDOObject {
                 if ($result) {
                     if ($pkn && !$pk) {
                         if ($pkGenerated) {
-                            // For compound PK, find the generated field and set it (fix #129)
-                            $generatedKey = $this->getGeneratedKey();
-                            $pkFields = (array) $this->getPK();
-                            foreach ($pkFields as $pkField) {
-                                if (isset($this->_fieldMeta[$pkField]['generated'])
-                                    && $this->_fieldMeta[$pkField]['generated'] === 'native') {
-                                    $this->_fields[$pkField] = $generatedKey;
-                                    break;
+                            if (is_array($pkn)) {
+                                $generatedKey = $this->getGeneratedKey();
+                                foreach ($pkn as $pkField => $v) {
+                                    if (isset($this->_fieldMeta[$pkField]['generated'])
+                                        && $this->_fieldMeta[$pkField]['generated'] === 'native') {
+                                        $this->_fields[$pkField] = $generatedKey;
+                                        break;
+                                    }
                                 }
+                            } else {
+                                $this->_fields[$this->getPK()] = $this->getGeneratedKey();
                             }
                         }
                         $pk = $this->getPrimaryKey();
@@ -1487,13 +1489,9 @@ class xPDOObject {
                         $this->_dirty= array();
                         $this->_validated= array();
                         $this->_new= false;
-                    } elseif ($result && $this->_new && $pkGenerated) {
-                        // Successfully inserted with generated PK - ensure we're no longer new
-                        // (getPrimaryKey may return falsy for compound PK with generated field
-                        // when lastInsertId returns 0 or getPrimaryKey validation fails)
-                        $this->_dirty= array();
-                        $this->_validated= array();
-                        $this->_new= false;
+                    }
+                    if (!$pk && $pkGenerated) {
+                        $this->xpdo->log(xPDO::LOG_LEVEL_WARN, "Could not retrieve generated key for class {$this->_class}.", '', __METHOD__, __FILE__, __LINE__);
                     }
                     $callback = $this->getOption(xPDO::OPT_CALLBACK_ON_SAVE);
                     if ($callback && is_callable($callback)) {

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -1487,6 +1487,13 @@ class xPDOObject {
                         $this->_dirty= array();
                         $this->_validated= array();
                         $this->_new= false;
+                    } elseif ($result && $this->_new && $pkGenerated) {
+                        // Successfully inserted with generated PK - ensure we're no longer new
+                        // (getPrimaryKey may return falsy for compound PK with generated field
+                        // when lastInsertId returns 0 or getPrimaryKey validation fails)
+                        $this->_dirty= array();
+                        $this->_validated= array();
+                        $this->_new= false;
                     }
                     $callback = $this->getOption(xPDO::OPT_CALLBACK_ON_SAVE);
                     if ($callback && is_callable($callback)) {

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -1470,9 +1470,18 @@ class xPDOObject {
                 if ($result) {
                     if ($pkn && !$pk) {
                         if ($pkGenerated) {
-                            $this->_fields[$this->getPK()]= $this->getGeneratedKey();
+                            // For compound PK, find the generated field and set it (fix #129)
+                            $generatedKey = $this->getGeneratedKey();
+                            $pkFields = (array) $this->getPK();
+                            foreach ($pkFields as $pkField) {
+                                if (isset($this->_fieldMeta[$pkField]['generated'])
+                                    && $this->_fieldMeta[$pkField]['generated'] === 'native') {
+                                    $this->_fields[$pkField] = $generatedKey;
+                                    break;
+                                }
+                            }
                         }
-                        $pk= $this->getPrimaryKey();
+                        $pk = $this->getPrimaryKey();
                     }
                     if ($pk || !$this->getPK()) {
                         $this->_dirty= array();

--- a/test/model/schema/xPDO.Test.Sample.mysql.schema.xml
+++ b/test/model/schema/xPDO.Test.Sample.mysql.schema.xml
@@ -88,6 +88,16 @@
             <column key="color" length="" collation="A" null="false" />
         </index>
     </object>
+    <object class="NumberSeq" table="number_seq" extends="xPDO\Om\xPDOObject">
+        <field key="level" dbtype="varchar" precision="1" phptype="string" null="false" index="pk" />
+        <field key="number" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" index="pk" generated="native" />
+
+        <!-- MySQL: AUTO_INCREMENT column must be first in composite PK -->
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="number" collation="A" null="false" />
+            <column key="level" collation="A" null="false" />
+        </index>
+    </object>
     <object class="SecureObject" extends="xPDO\Om\xPDOSimpleObject" />
     <object class="SecureItem" table="secure_items" extends="xPDO\Test\Sample\SecureObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" />

--- a/test/model/schema/xPDO.Test.Sample.pgsql.schema.xml
+++ b/test/model/schema/xPDO.Test.Sample.pgsql.schema.xml
@@ -88,6 +88,15 @@
             <column key="color" length="" collation="A" null="false" />
         </index>
     </object>
+    <object class="NumberSeq" table="number_seq" extends="xPDO\Om\xPDOObject">
+        <field key="level" dbtype="varchar" precision="1" phptype="string" null="false" index="pk" />
+        <field key="number" dbtype="integer" phptype="integer" null="false" index="pk" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="level" collation="A" null="false" />
+            <column key="number" collation="A" null="false" />
+        </index>
+    </object>
 
     <object class="SecureObject" extends="xPDO\Om\xPDOSimpleObject" />
     <object class="SecureItem" table="secure_items" extends="xPDO\Test\Sample\SecureObject">

--- a/test/model/schema/xPDO.Test.Sample.pgsql.schema.xml
+++ b/test/model/schema/xPDO.Test.Sample.pgsql.schema.xml
@@ -88,16 +88,6 @@
             <column key="color" length="" collation="A" null="false" />
         </index>
     </object>
-    <object class="NumberSeq" table="number_seq" extends="xPDO\Om\xPDOObject">
-        <field key="level" dbtype="varchar" precision="1" phptype="string" null="false" index="pk" />
-        <field key="number" dbtype="integer" phptype="integer" null="false" index="pk" />
-
-        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
-            <column key="level" collation="A" null="false" />
-            <column key="number" collation="A" null="false" />
-        </index>
-    </object>
-
     <object class="SecureObject" extends="xPDO\Om\xPDOSimpleObject" />
     <object class="SecureItem" table="secure_items" extends="xPDO\Test\Sample\SecureObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" />

--- a/test/model/schema/xPDO.Test.Sample.sqlite.schema.xml
+++ b/test/model/schema/xPDO.Test.Sample.sqlite.schema.xml
@@ -85,15 +85,6 @@
 
         <aggregate alias="Person" class="xPDO\Test\Sample\Person" local="type" foreign="blood_type" cardinality="many" owner="foreign" />
     </object>
-    <object class="NumberSeq" table="number_seq" extends="xPDO\Om\xPDOObject">
-        <field key="level" dbtype="varchar" precision="1" phptype="string" null="false" index="pk" />
-        <field key="number" dbtype="int" precision="10" phptype="integer" null="false" index="pk" />
-
-        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
-            <column key="level" collation="A" null="false" />
-            <column key="number" collation="A" null="false" />
-        </index>
-    </object>
     <object class="Item" table="items" extends="xPDO\Om\xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="fk" />
         <field key="color" dbtype="varchar" precision="255" phptype="string" null="false" default="green" index="fk" />

--- a/test/model/schema/xPDO.Test.Sample.sqlite.schema.xml
+++ b/test/model/schema/xPDO.Test.Sample.sqlite.schema.xml
@@ -85,6 +85,15 @@
 
         <aggregate alias="Person" class="xPDO\Test\Sample\Person" local="type" foreign="blood_type" cardinality="many" owner="foreign" />
     </object>
+    <object class="NumberSeq" table="number_seq" extends="xPDO\Om\xPDOObject">
+        <field key="level" dbtype="varchar" precision="1" phptype="string" null="false" index="pk" />
+        <field key="number" dbtype="int" precision="10" phptype="integer" null="false" index="pk" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
+            <column key="level" collation="A" null="false" />
+            <column key="number" collation="A" null="false" />
+        </index>
+    </object>
     <object class="Item" table="items" extends="xPDO\Om\xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="fk" />
         <field key="color" dbtype="varchar" precision="255" phptype="string" null="false" default="green" index="fk" />

--- a/test/model/xPDO/Test/Sample/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/NumberSeq.php
@@ -1,6 +1,14 @@
 <?php
 namespace xPDO\Test\Sample;
 
+use xPDO\xPDO;
+
+/**
+ * Class NumberSeq
+ *
+ *
+ * @package xPDO\Test\Sample
+ */
 class NumberSeq extends \xPDO\Om\xPDOObject
 {
 }

--- a/test/model/xPDO/Test/Sample/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/NumberSeq.php
@@ -1,0 +1,6 @@
+<?php
+namespace xPDO\Test\Sample;
+
+class NumberSeq extends \xPDO\Om\xPDOObject
+{
+}

--- a/test/model/xPDO/Test/Sample/metadata.mysql.php
+++ b/test/model/xPDO/Test/Sample/metadata.mysql.php
@@ -3,9 +3,9 @@ $xpdo_meta_map = array (
     'version' => '3.0',
     'namespace' => 'xPDO\\Test\\Sample',
     'namespacePrefix' => '',
-    'class_map' => 
+    'class_map' =>
     array (
-        'xPDO\\Om\\xPDOSimpleObject' => 
+        'xPDO\\Om\\xPDOSimpleObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\Person',
             1 => 'xPDO\\Test\\Sample\\Phone',
@@ -13,12 +13,13 @@ $xpdo_meta_map = array (
             3 => 'xPDO\\Test\\Sample\\Item',
             4 => 'xPDO\\Test\\Sample\\SecureObject',
         ),
-        'xPDO\\Om\\xPDOObject' => 
+        'xPDO\\Om\\xPDOObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\PersonPhone',
             1 => 'xPDO\\Test\\Sample\\BloodType',
+            2 => 'xPDO\\Test\\Sample\\NumberSeq',
         ),
-        'xPDO\\Test\\Sample\\SecureObject' => 
+        'xPDO\\Test\\Sample\\SecureObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\SecureItem',
         ),

--- a/test/model/xPDO/Test/Sample/metadata.pgsql.php
+++ b/test/model/xPDO/Test/Sample/metadata.pgsql.php
@@ -3,9 +3,9 @@ $xpdo_meta_map = array (
     'version' => '3.0',
     'namespace' => 'xPDO\\Test\\Sample',
     'namespacePrefix' => '',
-    'class_map' => 
+    'class_map' =>
     array (
-        'xPDO\\Om\\xPDOSimpleObject' => 
+        'xPDO\\Om\\xPDOSimpleObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\Person',
             1 => 'xPDO\\Test\\Sample\\Phone',
@@ -13,12 +13,13 @@ $xpdo_meta_map = array (
             3 => 'xPDO\\Test\\Sample\\Item',
             4 => 'xPDO\\Test\\Sample\\SecureObject',
         ),
-        'xPDO\\Om\\xPDOObject' => 
+        'xPDO\\Om\\xPDOObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\PersonPhone',
             1 => 'xPDO\\Test\\Sample\\BloodType',
+            2 => 'xPDO\\Test\\Sample\\NumberSeq',
         ),
-        'xPDO\\Test\\Sample\\SecureObject' => 
+        'xPDO\\Test\\Sample\\SecureObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\SecureItem',
         ),

--- a/test/model/xPDO/Test/Sample/metadata.pgsql.php
+++ b/test/model/xPDO/Test/Sample/metadata.pgsql.php
@@ -17,7 +17,6 @@ $xpdo_meta_map = array (
         array (
             0 => 'xPDO\\Test\\Sample\\PersonPhone',
             1 => 'xPDO\\Test\\Sample\\BloodType',
-            2 => 'xPDO\\Test\\Sample\\NumberSeq',
         ),
         'xPDO\\Test\\Sample\\SecureObject' =>
         array (

--- a/test/model/xPDO/Test/Sample/metadata.sqlite.php
+++ b/test/model/xPDO/Test/Sample/metadata.sqlite.php
@@ -3,9 +3,9 @@ $xpdo_meta_map = array (
     'version' => '3.0',
     'namespace' => 'xPDO\\Test\\Sample',
     'namespacePrefix' => '',
-    'class_map' => 
+    'class_map' =>
     array (
-        'xPDO\\Om\\xPDOSimpleObject' => 
+        'xPDO\\Om\\xPDOSimpleObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\Person',
             1 => 'xPDO\\Test\\Sample\\Phone',
@@ -13,12 +13,13 @@ $xpdo_meta_map = array (
             3 => 'xPDO\\Test\\Sample\\Item',
             4 => 'xPDO\\Test\\Sample\\SecureObject',
         ),
-        'xPDO\\Om\\xPDOObject' => 
+        'xPDO\\Om\\xPDOObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\PersonPhone',
             1 => 'xPDO\\Test\\Sample\\BloodType',
+            2 => 'xPDO\\Test\\Sample\\NumberSeq',
         ),
-        'xPDO\\Test\\Sample\\SecureObject' => 
+        'xPDO\\Test\\Sample\\SecureObject' =>
         array (
             0 => 'xPDO\\Test\\Sample\\SecureItem',
         ),

--- a/test/model/xPDO/Test/Sample/metadata.sqlite.php
+++ b/test/model/xPDO/Test/Sample/metadata.sqlite.php
@@ -17,7 +17,6 @@ $xpdo_meta_map = array (
         array (
             0 => 'xPDO\\Test\\Sample\\PersonPhone',
             1 => 'xPDO\\Test\\Sample\\BloodType',
-            2 => 'xPDO\\Test\\Sample\\NumberSeq',
         ),
         'xPDO\\Test\\Sample\\SecureObject' =>
         array (

--- a/test/model/xPDO/Test/Sample/mysql/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/mysql/NumberSeq.php
@@ -1,0 +1,61 @@
+<?php
+namespace xPDO\Test\Sample\mysql;
+
+class NumberSeq extends \xPDO\Test\Sample\NumberSeq
+{
+
+    public static $metaMap = array (
+        'package' => 'xPDO\\Test\\Sample',
+        'version' => '3.0',
+        'table' => 'number_seq',
+        'extends' => 'xPDO\\Om\\xPDOObject',
+        'fields' =>
+        array (
+            'level' => NULL,
+            'number' => NULL,
+        ),
+        'fieldMeta' =>
+        array (
+            'level' =>
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '1',
+                'phptype' => 'string',
+                'null' => false,
+            ),
+            'number' =>
+            array (
+                'dbtype' => 'int',
+                'precision' => '10',
+                'attributes' => 'unsigned',
+                'phptype' => 'integer',
+                'null' => false,
+                'generated' => 'native',
+            ),
+        ),
+        'indexes' =>
+        array (
+            'PRIMARY' =>
+            array (
+                'alias' => 'PRIMARY',
+                'primary' => true,
+                'unique' => true,
+                'type' => 'BTREE',
+                'columns' =>
+                array (
+                    'number' =>
+                    array (
+                        'collation' => 'A',
+                        'null' => false,
+                    ),
+                    'level' =>
+                    array (
+                        'collation' => 'A',
+                        'null' => false,
+                    ),
+                ),
+            ),
+        ),
+    );
+
+}

--- a/test/model/xPDO/Test/Sample/mysql/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/mysql/NumberSeq.php
@@ -1,6 +1,8 @@
 <?php
 namespace xPDO\Test\Sample\mysql;
 
+use xPDO\xPDO;
+
 class NumberSeq extends \xPDO\Test\Sample\NumberSeq
 {
 
@@ -9,46 +11,48 @@ class NumberSeq extends \xPDO\Test\Sample\NumberSeq
         'version' => '3.0',
         'table' => 'number_seq',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'level' => NULL,
             'number' => NULL,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'level' =>
+            'level' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '1',
                 'phptype' => 'string',
                 'null' => false,
+                'index' => 'pk',
             ),
-            'number' =>
+            'number' => 
             array (
                 'dbtype' => 'int',
                 'precision' => '10',
                 'attributes' => 'unsigned',
                 'phptype' => 'integer',
                 'null' => false,
+                'index' => 'pk',
                 'generated' => 'native',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'number' =>
+                    'number' => 
                     array (
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'level' =>
+                    'level' => 
                     array (
                         'collation' => 'A',
                         'null' => false,

--- a/test/model/xPDO/Test/Sample/pgsql/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/pgsql/NumberSeq.php
@@ -1,0 +1,58 @@
+<?php
+namespace xPDO\Test\Sample\pgsql;
+
+class NumberSeq extends \xPDO\Test\Sample\NumberSeq
+{
+
+    public static $metaMap = array (
+        'package' => 'xPDO\\Test\\Sample',
+        'version' => '3.0',
+        'table' => 'number_seq',
+        'extends' => 'xPDO\\Om\\xPDOObject',
+        'fields' =>
+        array (
+            'level' => NULL,
+            'number' => NULL,
+        ),
+        'fieldMeta' =>
+        array (
+            'level' =>
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '1',
+                'phptype' => 'string',
+                'null' => false,
+            ),
+            'number' =>
+            array (
+                'dbtype' => 'integer',
+                'phptype' => 'integer',
+                'null' => false,
+            ),
+        ),
+        'indexes' =>
+        array (
+            'PRIMARY' =>
+            array (
+                'alias' => 'PRIMARY',
+                'primary' => true,
+                'unique' => true,
+                'type' => 'BTREE',
+                'columns' =>
+                array (
+                    'level' =>
+                    array (
+                        'collation' => 'A',
+                        'null' => false,
+                    ),
+                    'number' =>
+                    array (
+                        'collation' => 'A',
+                        'null' => false,
+                    ),
+                ),
+            ),
+        ),
+    );
+
+}

--- a/test/model/xPDO/Test/Sample/pgsql/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/pgsql/NumberSeq.php
@@ -1,6 +1,8 @@
 <?php
 namespace xPDO\Test\Sample\pgsql;
 
+use xPDO\xPDO;
+
 class NumberSeq extends \xPDO\Test\Sample\NumberSeq
 {
 
@@ -9,43 +11,45 @@ class NumberSeq extends \xPDO\Test\Sample\NumberSeq
         'version' => '3.0',
         'table' => 'number_seq',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'level' => NULL,
             'number' => NULL,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'level' =>
+            'level' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '1',
                 'phptype' => 'string',
                 'null' => false,
+                'index' => 'pk',
             ),
-            'number' =>
+            'number' => 
             array (
                 'dbtype' => 'integer',
                 'phptype' => 'integer',
                 'null' => false,
+                'index' => 'pk',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'level' =>
+                    'level' => 
                     array (
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'number' =>
+                    'number' => 
                     array (
                         'collation' => 'A',
                         'null' => false,

--- a/test/model/xPDO/Test/Sample/sqlite/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/sqlite/NumberSeq.php
@@ -1,0 +1,58 @@
+<?php
+namespace xPDO\Test\Sample\sqlite;
+
+class NumberSeq extends \xPDO\Test\Sample\NumberSeq
+{
+
+    public static $metaMap = array (
+        'package' => 'xPDO\\Test\\Sample',
+        'version' => '3.0',
+        'table' => 'number_seq',
+        'extends' => 'xPDO\\Om\\xPDOObject',
+        'fields' =>
+        array (
+            'level' => NULL,
+            'number' => NULL,
+        ),
+        'fieldMeta' =>
+        array (
+            'level' =>
+            array (
+                'dbtype' => 'varchar',
+                'precision' => '1',
+                'phptype' => 'string',
+                'null' => false,
+            ),
+            'number' =>
+            array (
+                'dbtype' => 'int',
+                'precision' => '10',
+                'phptype' => 'integer',
+                'null' => false,
+            ),
+        ),
+        'indexes' =>
+        array (
+            'PRIMARY' =>
+            array (
+                'alias' => 'PRIMARY',
+                'primary' => true,
+                'unique' => true,
+                'columns' =>
+                array (
+                    'level' =>
+                    array (
+                        'collation' => 'A',
+                        'null' => false,
+                    ),
+                    'number' =>
+                    array (
+                        'collation' => 'A',
+                        'null' => false,
+                    ),
+                ),
+            ),
+        ),
+    );
+
+}

--- a/test/model/xPDO/Test/Sample/sqlite/NumberSeq.php
+++ b/test/model/xPDO/Test/Sample/sqlite/NumberSeq.php
@@ -1,6 +1,8 @@
 <?php
 namespace xPDO\Test\Sample\sqlite;
 
+use xPDO\xPDO;
+
 class NumberSeq extends \xPDO\Test\Sample\NumberSeq
 {
 
@@ -9,43 +11,45 @@ class NumberSeq extends \xPDO\Test\Sample\NumberSeq
         'version' => '3.0',
         'table' => 'number_seq',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'level' => NULL,
             'number' => NULL,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'level' =>
+            'level' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '1',
                 'phptype' => 'string',
                 'null' => false,
+                'index' => 'pk',
             ),
-            'number' =>
+            'number' => 
             array (
                 'dbtype' => 'int',
                 'precision' => '10',
                 'phptype' => 'integer',
                 'null' => false,
+                'index' => 'pk',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
-                'columns' =>
+                'columns' => 
                 array (
-                    'level' =>
+                    'level' => 
                     array (
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'number' =>
+                    'number' => 
                     array (
                         'collation' => 'A',
                         'null' => false,

--- a/test/xPDO/Legacy/Om/xPDOObjectTest.php
+++ b/test/xPDO/Legacy/Om/xPDOObjectTest.php
@@ -385,13 +385,14 @@ class xPDOObjectTest extends TestCase
      */
     public function testGetObjectGraphsByPK()
     {
-        //array method
+        $person = null;
+        $personPhone = null;
+        $phone = null;
         try {
             $person = $this->xpdo->getObjectGraph('Person', array('PersonPhone' => array('Phone' => array())), 2);
             if ($person) {
                 $personPhoneColl = $person->getMany('PersonPhone');
                 if ($personPhoneColl) {
-                    $phone = null;
                     foreach ($personPhoneColl as $personPhone) {
                         if ($personPhone->get('phone') == 2) {
                             $phone = $personPhone->getOne('Phone');
@@ -404,7 +405,7 @@ class xPDOObjectTest extends TestCase
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
         $this->assertTrue($person instanceof \Person, "Error retrieving Person object by primary key via getObjectGraph");
-        $this->assertTrue($personPhone instanceof \PersonPhone, "Error retrieving retreiving related PersonPhone collection via getObjectGraph");
+        $this->assertTrue($personPhone instanceof \PersonPhone, "Error retrieving related PersonPhone collection via getObjectGraph");
         $this->assertTrue($phone instanceof \Phone, "Error retrieving related Phone object via getObjectGraph");
     }
 
@@ -413,13 +414,14 @@ class xPDOObjectTest extends TestCase
      */
     public function testGetObjectGraphsJSONByPK()
     {
-        //JSON method
+        $person = null;
+        $personPhone = null;
+        $phone = null;
         try {
             $person = $this->xpdo->getObjectGraph('Person', '{"PersonPhone":{"Phone":{}}}', 2);
             if ($person) {
                 $personPhoneColl = $person->getMany('PersonPhone');
                 if ($personPhoneColl) {
-                    $phone = null;
                     foreach ($personPhoneColl as $personPhone) {
                         if ($personPhone->get('phone') == 2) {
                             $phone = $personPhone->getOne('Phone');
@@ -432,7 +434,7 @@ class xPDOObjectTest extends TestCase
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
         $this->assertTrue($person instanceof \Person, "Error retrieving Person object by primary key via getObjectGraph, JSON graph");
-        $this->assertTrue($personPhone instanceof \PersonPhone, "Error retrieving retreiving related PersonPhone collection via getObjectGraph, JSON graph");
+        $this->assertTrue($personPhone instanceof \PersonPhone, "Error retrieving related PersonPhone collection via getObjectGraph, JSON graph");
         $this->assertTrue($phone instanceof \Phone, "Error retrieving related Phone object via getObjectGraph, JSON graph");
     }
 

--- a/test/xPDO/Test/Om/xPDOObjectTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectTest.php
@@ -258,6 +258,35 @@ class xPDOObjectTest extends TestCase
     }
 
     /**
+     * Test saving an object with compound primary key that includes a generated field.
+     * Covers fix for #129: "PHP warning: Illegal offset type" when saving such objects.
+     *
+     * @requires extension pdo_mysql
+     */
+    public function testSaveCompoundPkWithGeneratedField()
+    {
+        if (self::$properties['xpdo_driver'] !== 'mysql') {
+            $this->markTestSkipped('NumberSeq model is MySQL-only (compound PK with AUTO_INCREMENT)');
+        }
+        $this->xpdo->getManager();
+        $this->xpdo->manager->createObjectContainer('xPDO\\Test\\Sample\\NumberSeq');
+
+        $number = $this->xpdo->newObject('xPDO\\Test\\Sample\\NumberSeq');
+        $number->fromArray(array('level' => 'B', 'number' => null), '', true);
+
+        $result = $number->save();
+        $msg = 'Save should succeed without PHP warnings';
+        if (!$result) {
+            $msg .= '. Error: ' . print_r($this->xpdo->errorInfo(), true);
+        }
+        $this->assertTrue($result, $msg);
+        $this->assertNotNull($number->get('number'), 'Generated number field should be set after save');
+        $this->assertFalse($number->isNew(), 'Object should not be new after save');
+
+        $this->xpdo->manager->removeObjectContainer('xPDO\\Test\\Sample\\NumberSeq');
+    }
+
+    /**
      * Test saving an object.
      */
     public function testSaveObject()
@@ -382,13 +411,14 @@ class xPDOObjectTest extends TestCase
      */
     public function testGetObjectGraphsByPK()
     {
-        //array method
+        $person = null;
+        $personPhone = null;
+        $phone = null;
         try {
             $person = $this->xpdo->getObjectGraph('xPDO\\Test\\Sample\\Person', array('PersonPhone' => array('Phone' => array())), 2);
             if ($person) {
                 $personPhoneColl = $person->getMany('PersonPhone');
                 if ($personPhoneColl) {
-                    $phone = null;
                     foreach ($personPhoneColl as $personPhone) {
                         if ($personPhone->get('phone') == 2) {
                             $phone = $personPhone->getOne('Phone');
@@ -401,7 +431,7 @@ class xPDOObjectTest extends TestCase
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
         $this->assertTrue($person instanceof \xPDO\Test\Sample\Person, "Error retrieving Person object by primary key via getObjectGraph");
-        $this->assertTrue($personPhone instanceof \xPDO\Test\Sample\PersonPhone, "Error retrieving retreiving related PersonPhone collection via getObjectGraph");
+        $this->assertTrue($personPhone instanceof \xPDO\Test\Sample\PersonPhone, "Error retrieving related PersonPhone collection via getObjectGraph");
         $this->assertTrue($phone instanceof \xPDO\Test\Sample\Phone, "Error retrieving related Phone object via getObjectGraph");
     }
 
@@ -431,13 +461,14 @@ class xPDOObjectTest extends TestCase
      */
     public function testGetObjectGraphsJSONByPK()
     {
-        //JSON method
+        $person = null;
+        $personPhone = null;
+        $phone = null;
         try {
             $person = $this->xpdo->getObjectGraph('xPDO\\Test\\Sample\\Person', '{"PersonPhone":{"Phone":{}}}', 2);
             if ($person) {
                 $personPhoneColl = $person->getMany('PersonPhone');
                 if ($personPhoneColl) {
-                    $phone = null;
                     foreach ($personPhoneColl as $personPhone) {
                         if ($personPhone->get('phone') == 2) {
                             $phone = $personPhone->getOne('Phone');
@@ -450,7 +481,7 @@ class xPDOObjectTest extends TestCase
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
         $this->assertTrue($person instanceof \xPDO\Test\Sample\Person, "Error retrieving Person object by primary key via getObjectGraph, JSON graph");
-        $this->assertTrue($personPhone instanceof \xPDO\Test\Sample\PersonPhone, "Error retrieving retreiving related PersonPhone collection via getObjectGraph, JSON graph");
+        $this->assertTrue($personPhone instanceof \xPDO\Test\Sample\PersonPhone, "Error retrieving related PersonPhone collection via getObjectGraph, JSON graph");
         $this->assertTrue($phone instanceof \xPDO\Test\Sample\Phone, "Error retrieving related Phone object via getObjectGraph, JSON graph");
     }
 

--- a/test/xPDO/Test/xPDOTest.php
+++ b/test/xPDO/Test/xPDOTest.php
@@ -273,12 +273,13 @@ class xPDOTest extends TestCase
                     0 => 'xPDO\\Om\\xPDOSimpleObject',
                     1 => 'xPDO\\Test\\Sample\\PersonPhone',
                     2 => 'xPDO\\Test\\Sample\\BloodType',
-                    3 => 'xPDO\\Test\\Sample\\Person',
-                    4 => 'xPDO\\Test\\Sample\\Phone',
-                    5 => 'xPDO\\Test\\Sample\\xPDOSample',
-                    6 => 'xPDO\\Test\\Sample\\Item',
-                    7 => 'xPDO\\Test\\Sample\\SecureObject',
-                    8 => 'xPDO\\Test\\Sample\\SecureItem'
+                    3 => 'xPDO\\Test\\Sample\\NumberSeq',
+                    4 => 'xPDO\\Test\\Sample\\Person',
+                    5 => 'xPDO\\Test\\Sample\\Phone',
+                    6 => 'xPDO\\Test\\Sample\\xPDOSample',
+                    7 => 'xPDO\\Test\\Sample\\Item',
+                    8 => 'xPDO\\Test\\Sample\\SecureObject',
+                    9 => 'xPDO\\Test\\Sample\\SecureItem'
                 )
             ),
         );

--- a/test/xPDO/Test/xPDOTest.php
+++ b/test/xPDO/Test/xPDOTest.php
@@ -247,6 +247,13 @@ class xPDOTest extends TestCase
      */
     public function testGetDescendants($class, array $correct = array())
     {
+        // NumberSeq only exists in the MySQL schema (compound PK with native-generated field
+        // is MySQL-only), so remove it from the expected set on other drivers.
+        if (self::$properties['xpdo_driver'] !== 'mysql') {
+            $correct = array_values(array_filter($correct, function ($c) {
+                return $c !== 'xPDO\\Test\\Sample\\NumberSeq';
+            }));
+        }
         $this->assertEquals($correct, $this->xpdo->getDescendants($class));
     }
 


### PR DESCRIPTION
Fix PHP warning "Illegal offset type" when saving objects with compound primary key that includes a generated field (e.g. AUTO_INCREMENT).

**Problem**
When `getPK()` returns an array for compound keys, the code used it as array index: `$this->_fields[$this->getPK()]` — PHP does not allow arrays as array keys.

**Solution**
- **xPDOObject::save()**: Iterate over PK fields, find the one with `generated="native"`, and set only that field with `getGeneratedKey()`
- **xPDOManager (MySQL)**: Extend `getColumnDef` to add AUTO_INCREMENT for generated fields in compound PK (only for the first column in PK, per MySQL requirement)

**Additional changes**
- Add NumberSeq test model and `testSaveCompoundPkWithGeneratedField` test
- Fix variable initialization in `testGetObjectGraphsByPK` / `testGetObjectGraphsJSONByPK` to avoid undefined variable notices
- Fix typo "retreiving" → "retrieving" in test messages

Fixes #129