### PR TITLE
Fix xPDOQuery::set() SQL keyword handling; introduce xPDOExpression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -114,7 +114,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.4",
         "ext-PDO": "*",
         "ext-json": "*",
         "ext-simplexml": "*",

--- a/src/xPDO/Om/mysql/xPDOQuery.php
+++ b/src/xPDO/Om/mysql/xPDOQuery.php
@@ -78,7 +78,9 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                 foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
-                    if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
+                    if ($value instanceof \xPDO\Om\xPDOExpression) {
+                        $value = $value->getExpression();
+                    } elseif ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
                         $value = $this->xpdo->quote($value, $type);
                     } elseif ($value === null) {
                         $value = 'NULL';

--- a/src/xPDO/Om/pgsql/xPDOQuery.php
+++ b/src/xPDO/Om/pgsql/xPDOQuery.php
@@ -69,7 +69,9 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery
                 foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
-                    if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
+                    if ($value instanceof \xPDO\Om\xPDOExpression) {
+                        $value = $value->getExpression();
+                    } elseif ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
                         $value = $this->xpdo->quote($value, $type);
                     } elseif ($value === null) {
                         $value = 'NULL';

--- a/src/xPDO/Om/sqlite/xPDOQuery.php
+++ b/src/xPDO/Om/sqlite/xPDOQuery.php
@@ -78,7 +78,9 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                 foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
-                    if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
+                    if ($value instanceof \xPDO\Om\xPDOExpression) {
+                        $value = $value->getExpression();
+                    } elseif ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
                         $value = $this->xpdo->quote($value, $type);
                     } elseif ($value === null) {
                         $value = 'NULL';

--- a/src/xPDO/Om/sqlsrv/xPDOQuery.php
+++ b/src/xPDO/Om/sqlsrv/xPDOQuery.php
@@ -249,7 +249,9 @@ class xPDOQuery extends \xPDO\Om\xPDOQuery {
                 foreach ($this->query['set'] as $setKey => $setVal) {
                     $value = $setVal['value'];
                     $type = $setVal['type'];
-                    if ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
+                    if ($value instanceof \xPDO\Om\xPDOExpression) {
+                        $value = $value->getExpression();
+                    } elseif ($value !== null && in_array($type, array(\PDO::PARAM_INT, \PDO::PARAM_STR))) {
                         $value = $this->xpdo->quote($value, $type);
                     } elseif ($value === null) {
                         $value = 'NULL';

--- a/src/xPDO/Om/xPDOExpression.php
+++ b/src/xPDO/Om/xPDOExpression.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Om;
+
+/**
+ * Wraps a raw SQL expression for use in query SET clauses, bypassing automatic quoting.
+ *
+ * Use this class to explicitly indicate that a value should be treated as a raw
+ * SQL fragment rather than a literal string to be quoted. This is analogous to
+ * Laravel's DB::raw().
+ *
+ * Plain PHP strings passed to xPDOQuery::set() or xPDO::updateCollection() are
+ * always quoted/escaped for SQL injection safety. Wrap a value in xPDOExpression
+ * only when you intentionally need raw SQL, such as:
+ *
+ * <code>
+ * // Increment a counter column using a SQL expression
+ * $xpdo->updateCollection('MyClass', [
+ *     'view_count' => $xpdo->expression('view_count + 1'),
+ * ]);
+ *
+ * // Use a SQL function as a SET value
+ * $object->set('updated_at', $xpdo->expression('NOW()'));
+ * $object->save();
+ * </code>
+ *
+ * @package xPDO\Om
+ */
+final class xPDOExpression
+{
+    /** @var string The raw SQL expression string. */
+    private string $expression;
+
+    /**
+     * @param string $expression The raw SQL expression to use verbatim.
+     */
+    public function __construct(string $expression)
+    {
+        $this->expression = $expression;
+    }
+
+    /**
+     * Returns the raw SQL expression string.
+     *
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->expression;
+    }
+}

--- a/src/xPDO/Om/xPDOObject.php
+++ b/src/xPDO/Om/xPDOObject.php
@@ -798,7 +798,13 @@ class xPDOObject {
                         $phptype= $this->_fieldMeta[$k]['phptype'];
                         $dbtype= $this->_fieldMeta[$k]['dbtype'];
                         $allowNull= isset($this->_fieldMeta[$k]['null']) ? (bool) $this->_fieldMeta[$k]['null'] : true;
-                        if ($v === null) {
+                        if ($v instanceof \xPDO\Om\xPDOExpression) {
+                            // Raw SQL expression: bypass type coercion and store as-is.
+                            // The expression will be inlined verbatim in save().
+                            $this->_fields[$k]= $v;
+                            $set= true;
+                        }
+                        elseif ($v === null) {
                             if ($allowNull) {
                                 $this->_fields[$k]= null;
                                 $set= true;
@@ -1349,6 +1355,7 @@ class xPDOObject {
         if (!empty ($this->_dirty)) {
             $cols= array ();
             $bindings= array ();
+            $valuesSql= array ();
             $updateSql= array ();
             foreach (array_keys($this->_dirty) as $_k) {
                 if (!array_key_exists($_k, $this->_fieldMeta)) {
@@ -1360,12 +1367,22 @@ class xPDOObject {
                         continue;
                     }
                 }
-                if ($this->_fieldMeta[$_k]['phptype'] === 'password') {
+                if ($this->_fieldMeta[$_k]['phptype'] === 'password' && !($this->_fields[$_k] instanceof \xPDO\Om\xPDOExpression)) {
                     $this->_fields[$_k]= $this->encode($this->_fields[$_k], 'password');
                 }
                 $fieldType= \PDO::PARAM_STR;
                 $fieldValue= $this->_fields[$_k];
-                if (in_array($this->_fieldMeta[$_k]['phptype'], array ('datetime', 'timestamp')) && !empty($this->_fieldMeta[$_k]['attributes']) && $this->_fieldMeta[$_k]['attributes'] == 'ON UPDATE CURRENT_TIMESTAMP') {
+                if ($fieldValue instanceof \xPDO\Om\xPDOExpression) {
+                    // Raw SQL expression: inline verbatim, do not create a PDO binding.
+                    if ($this->_new) {
+                        $cols[$_k]= $this->xpdo->escape($_k);
+                        $valuesSql[$_k]= $fieldValue->getExpression();
+                    } else {
+                        $updateSql[]= $this->xpdo->escape($_k) . ' = ' . $fieldValue->getExpression();
+                    }
+                    continue;
+                }
+                elseif (in_array($this->_fieldMeta[$_k]['phptype'], array ('datetime', 'timestamp')) && !empty($this->_fieldMeta[$_k]['attributes']) && $this->_fieldMeta[$_k]['attributes'] == 'ON UPDATE CURRENT_TIMESTAMP') {
                     $this->_fields[$_k]= date('Y-m-d H:i:s');
                     continue;
                 }
@@ -1392,6 +1409,7 @@ class xPDOObject {
                     $cols[$_k]= $this->xpdo->escape($_k);
                     $bindings[":{$_k}"]['value']= $fieldValue;
                     $bindings[":{$_k}"]['type']= $fieldType;
+                    $valuesSql[$_k]= ":{$_k}";
                 } else {
                     $bindings[":{$_k}"]['value']= $fieldValue;
                     $bindings[":{$_k}"]['type']= $fieldType;
@@ -1399,7 +1417,7 @@ class xPDOObject {
                 }
             }
             if ($this->_new) {
-                $sql= "INSERT INTO {$this->_table} (" . implode(', ', array_values($cols)) . ") VALUES (" . implode(', ', array_keys($bindings)) . ")";
+                $sql= "INSERT INTO {$this->_table} (" . implode(', ', array_values($cols)) . ") VALUES (" . implode(', ', array_values($valuesSql)) . ")";
             } else {
                 if ($pk && $pkn) {
                     if (is_array($pkn)) {

--- a/src/xPDO/Om/xPDOQuery.php
+++ b/src/xPDO/Om/xPDOQuery.php
@@ -258,13 +258,18 @@ abstract class xPDOQuery extends xPDOCriteria {
                 }
             }
             if (array_key_exists($key, $fieldMeta)) {
-                if ($value === null) {
+                if ($value instanceof xPDOExpression) {
+                    // Raw SQL expression: leave $type as null so construct() uses it verbatim.
+                }
+                elseif ($value === null) {
                     $type= \PDO::PARAM_NULL;
                 }
                 elseif (!in_array($fieldMeta[$key]['phptype'], $this->_quotable)) {
                     $type= \PDO::PARAM_INT;
                 }
-                elseif (strpos($value, '(') === false && !$this->isConditionalClause($value)) {
+                else {
+                    // All plain string values are always quoted regardless of content.
+                    // Use xPDOExpression to explicitly pass raw SQL expressions.
                     $type= \PDO::PARAM_STR;
                 }
                 $this->query['set'][$key]= array('value' => $value, 'type' => $type);

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2683,6 +2683,22 @@ class xPDO {
     }
 
     /**
+     * Creates an xPDOExpression wrapper to mark a value as a raw SQL fragment.
+     *
+     * Use this when you need to pass a raw SQL expression as the value in a SET
+     * clause via updateCollection() or xPDOQuery::set(), bypassing automatic
+     * quoting and SQL injection protection. Plain PHP strings should always be
+     * passed without this wrapper.
+     *
+     * @param string $expression The raw SQL expression.
+     * @return Om\xPDOExpression
+     */
+    public function expression(string $expression): Om\xPDOExpression
+    {
+        return new Om\xPDOExpression($expression);
+    }
+
+    /**
      * Splits a string on a specified character, ignoring escaped content.
      *
      * @static

--- a/test/xPDO/Test/Om/xPDOExpressionTest.php
+++ b/test/xPDO/Test/Om/xPDOExpressionTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Om;
+
+use ReflectionClass;
+use xPDO\Om\xPDOExpression;
+use xPDO\TestCase;
+
+/**
+ * Tests for the xPDOExpression value object.
+ *
+ * @package xPDO\Test\Om
+ */
+class xPDOExpressionTest extends TestCase
+{
+    /**
+     * Test that the expression stores and returns the raw SQL string.
+     */
+    public function testExpressionStoresValue()
+    {
+        $expr = new xPDOExpression('NOW()');
+        $this->assertEquals('NOW()', $expr->getExpression());
+    }
+
+    /**
+     * Test that __toString() returns the raw SQL string.
+     */
+    public function testExpressionToString()
+    {
+        $expr = new xPDOExpression('NOW()');
+        $this->assertEquals('NOW()', (string)$expr);
+    }
+
+    /**
+     * Test that xPDOExpression is declared final to prevent subclassing.
+     */
+    public function testExpressionIsFinal()
+    {
+        $ref = new ReflectionClass(xPDOExpression::class);
+        $this->assertTrue($ref->isFinal());
+    }
+
+    /**
+     * Test the xPDO::expression() factory method returns an xPDOExpression.
+     */
+    public function testXpdoFactoryMethod()
+    {
+        $expr = $this->xpdo->expression('CURRENT_TIMESTAMP');
+        $this->assertInstanceOf(xPDOExpression::class, $expr);
+        $this->assertEquals('CURRENT_TIMESTAMP', $expr->getExpression());
+    }
+}

--- a/test/xPDO/Test/Om/xPDOObjectTest.php
+++ b/test/xPDO/Test/Om/xPDOObjectTest.php
@@ -10,6 +10,7 @@
 
 namespace xPDO\Test\Om;
 
+use xPDO\Om\xPDOExpression;
 use xPDO\Om\xPDOObject;
 use xPDO\Test\Sample\Person;
 use xPDO\TestCase;
@@ -805,5 +806,43 @@ class xPDOObjectTest extends TestCase
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $e->getMessage(), '', __METHOD__, __FILE__, __LINE__);
         }
         $this->assertTrue($result === 2, "Error removing a collection of objects.");
+    }
+
+    /**
+     * Test that xPDOObject::set() accepts an xPDOExpression and stores it without type coercion.
+     */
+    public function testObjectSetAcceptsExpression()
+    {
+        $person = $this->xpdo->newObject('xPDO\\Test\\Sample\\Person');
+        $expr = new xPDOExpression('UPPER(first_name)');
+        $result = $person->set('username', $expr);
+
+        $this->assertTrue($result, 'xPDOObject::set() should return true when setting an xPDOExpression.');
+        $stored = $person->get('username');
+        $this->assertInstanceOf(xPDOExpression::class, $stored, 'xPDOObject::get() should return the xPDOExpression instance as stored.');
+        $this->assertSame($expr, $stored, 'The stored value must be the same xPDOExpression instance.');
+    }
+
+    /**
+     * Test that xPDOObject::save() handles an xPDOExpression in an UPDATE (existing object).
+     */
+    public function testObjectSaveWithExpressionInUpdate()
+    {
+        $person = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', array('first_name' => 'Johnathon'));
+        $this->assertNotNull($person, 'Could not retrieve test person fixture.');
+
+        $originalLevel = (int)$person->get('security_level');
+
+        $person->set('security_level', $this->xpdo->expression('security_level + 5'));
+        $saveResult = $person->save();
+
+        $this->assertTrue($saveResult, 'xPDOObject::save() with an xPDOExpression should return true.');
+
+        $reloaded = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', $person->get('id'));
+        $this->assertEquals(
+            $originalLevel + 5,
+            (int)$reloaded->get('security_level'),
+            'xPDOExpression in save() should have incremented security_level by 5.'
+        );
     }
 }

--- a/test/xPDO/Test/Om/xPDOQueryTest.php
+++ b/test/xPDO/Test/Om/xPDOQueryTest.php
@@ -10,6 +10,7 @@
 
 namespace xPDO\Test\Om;
 
+use xPDO\Om\xPDOExpression;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 use xPDO\Om\xPDOQueryCondition;
@@ -589,5 +590,87 @@ class xPDOQueryTest extends TestCase {
             array("benchmark ( 999, 100+1 )"),
             array("if(now()=sysdate(),sleep (20),0)"),
         );
+    }
+
+    /**
+     * Test that updateCollection() succeeds when a string value contains SQL operator keywords.
+     *
+     * Regression test for https://github.com/modxcms/revolution/issues/9487
+     */
+    public function testUpdateCollectionWithSQLKeywordInString()
+    {
+        $person = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', array('first_name' => 'Johnathon'));
+        $this->assertNotNull($person, 'Could not retrieve test person fixture.');
+
+        $valueWithSQLKeyword = 'The word IN is IN this strINg';
+        $result = $this->xpdo->updateCollection(
+            'xPDO\\Test\\Sample\\Person',
+            array('username' => $valueWithSQLKeyword),
+            array('id' => $person->get('id'))
+        );
+
+        $this->assertNotFalse($result, 'updateCollection() returned false — SQL syntax error likely caused by SQL keyword in string value.');
+        $this->assertEquals(1, $result, 'updateCollection() should have updated exactly 1 row.');
+
+        $reloaded = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', $person->get('id'));
+        $this->assertEquals($valueWithSQLKeyword, $reloaded->get('username'), 'The saved value should match the original string with SQL keywords.');
+    }
+
+    /**
+     * Test that updateCollection() with an xPDOExpression executes raw SQL.
+     */
+    public function testUpdateCollectionWithExpression()
+    {
+        $person = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', array('first_name' => 'Johnathon'));
+        $this->assertNotNull($person, 'Could not retrieve test person fixture.');
+
+        $originalLevel = (int)$person->get('security_level');
+
+        $result = $this->xpdo->updateCollection(
+            'xPDO\\Test\\Sample\\Person',
+            array('security_level' => $this->xpdo->expression('security_level + 1')),
+            array('id' => $person->get('id'))
+        );
+
+        $this->assertNotFalse($result, 'updateCollection() with an xPDOExpression returned false.');
+        $this->assertEquals(1, $result, 'updateCollection() should have updated exactly 1 row.');
+
+        $reloaded = $this->xpdo->getObject('xPDO\\Test\\Sample\\Person', $person->get('id'));
+        $this->assertEquals($originalLevel + 1, (int)$reloaded->get('security_level'), 'xPDOExpression should have incremented security_level by 1.');
+    }
+
+    /**
+     * Test that xPDOQuery::set() assigns PDO::PARAM_STR to a string containing SQL keywords.
+     */
+    public function testSetQueryStringWithSQLKeywordIsParamStr()
+    {
+        $query = $this->xpdo->newQuery('xPDO\\Test\\Sample\\Person');
+        $query->command('UPDATE');
+        $query->set(array('username' => 'The word IN is IN this strINg'));
+
+        $this->assertArrayHasKey('username', $query->query['set'], 'Field should be present in query set.');
+        $this->assertEquals(
+            \PDO::PARAM_STR,
+            $query->query['set']['username']['type'],
+            'A plain string containing SQL keywords must be typed as PDO::PARAM_STR (always quoted).'
+        );
+    }
+
+    /**
+     * Test that xPDOQuery::set() assigns null type to an xPDOExpression (raw SQL sentinel).
+     */
+    public function testSetQueryWithExpressionObjectHasNullType()
+    {
+        $expr = new xPDOExpression('NOW()');
+        $query = $this->xpdo->newQuery('xPDO\\Test\\Sample\\Person');
+        $query->command('UPDATE');
+        $query->set(array('dob' => $expr));
+
+        $this->assertArrayHasKey('dob', $query->query['set'], 'Field should be present in query set.');
+        $this->assertNull(
+            $query->query['set']['dob']['type'],
+            'An xPDOExpression must have null type so construct() uses it verbatim.'
+        );
+        $this->assertSame($expr, $query->query['set']['dob']['value'], 'The xPDOExpression instance must be stored as the value.');
     }
 }


### PR DESCRIPTION
## Summary

Fixes #54. Supersedes #271.

### Commit 1 — Bug fix: `xPDOQuery::set()` misinterprets strings containing SQL keywords

**Bug:** `updateCollection()` (and any `xPDOQuery::set()` call) silently produced invalid SQL when a string value contained SQL operator keywords such as `IN`, `LIKE`, or `NOT`. The root cause was `set()` calling `isConditionalClause()` on values — any matching string was treated as a raw SQL expression and left unquoted.

**Fix:** Plain PHP strings in `xPDOQuery::set()` are now always assigned `PDO::PARAM_STR` and quoted, regardless of content. `isConditionalClause()` is removed from `set()` but preserved in `parseConditions()` where it belongs.

**Escape hatch — `xPDOExpression`:** A new final value object (`xPDO\Om\xPDOExpression`) explicitly marks a value as a raw SQL fragment, bypassing automatic quoting. Use `xPDO::expression()` as a factory. All four driver `construct()` methods, `xPDOQuery::set()`, `xPDOObject::set()`, and `xPDOObject::save()` recognise and inline `xPDOExpression` values verbatim.

```php
// Plain strings now always work correctly — never misinterpreted as SQL
$xpdo->updateCollection('MyClass', ['label' => 'The word IN is IN this strINg']);

// Use xPDOExpression for intentional raw SQL in SET clauses
$xpdo->updateCollection('MyClass', ['counter' => $xpdo->expression('counter + 1')]);
$object->set('updated_at', $xpdo->expression('NOW()'));
$object->save();
```

### Commit 2 — Bump minimum PHP version to 7.4; remove PHP 7.2/7.3 from CI

`xPDOExpression` uses typed class properties (`private string $expression`) which require PHP 7.4. Updates `composer.json` and the CI workflow matrix accordingly.

## Files changed

| File | Change |
|---|---|
| `src/xPDO/Om/xPDOExpression.php` | New value object for raw SQL expressions |
| `src/xPDO/Om/xPDOQuery.php` | Fix `set()` to always quote strings; inline `xPDOExpression` verbatim |
| `src/xPDO/xPDO.php` | Add `expression()` factory method |
| `src/xPDO/Om/mysql/xPDOQuery.php` | Inline `xPDOExpression` in SET clause |
| `src/xPDO/Om/pgsql/xPDOQuery.php` | Inline `xPDOExpression` in SET clause |
| `src/xPDO/Om/sqlite/xPDOQuery.php` | Inline `xPDOExpression` in SET clause |
| `src/xPDO/Om/sqlsrv/xPDOQuery.php` | Inline `xPDOExpression` in SET clause |
| `src/xPDO/Om/xPDOObject.php` | Recognise `xPDOExpression` in `set()` and `save()` |
| `composer.json` | Bump minimum PHP to 7.4 |
| `.github/workflows/ci.yml` | Remove PHP 7.2/7.3 from test matrix |
| `test/xPDO/Test/Om/xPDOExpressionTest.php` | Unit tests for xPDOExpression |
| `test/xPDO/Test/Om/xPDOQueryTest.php` | Integration tests for bug fix and xPDOExpression in SET |
| `test/xPDO/Test/Om/xPDOObjectTest.php` | Tests for xPDOExpression in xPDOObject::set() and save() |

## Test plan

- [x] `xPDOExpressionTest` — 4 tests passing
- [x] `xPDOQueryTest` — includes string-value bug fix tests and `xPDOExpression` in SET
- [x] `xPDOObjectTest` — includes `xPDOExpression` in `set()` and `save()`
- [x] `xPDOQueryHavingTest`, `xPDOQueryLimitTest`, `xPDOQuerySortByTest` — all passing
- [ ] `xPDOQueryConditionsTest` — pre-existing failures unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)