### PR TITLE
Fix createObjectContainer() uncaught PDOException on MySQL 8+

### DIFF
--- a/src/xPDO/Om/mysql/xPDOManager.php
+++ b/src/xPDO/Om/mysql/xPDOManager.php
@@ -114,9 +114,14 @@ class xPDOManager extends \xPDO\Om\xPDOManager {
             $instance= $this->xpdo->newObject($className);
             if ($instance) {
                 $tableName= $this->xpdo->getTableName($className);
-                $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
-                if ($existsStmt && $existsStmt->fetchAll()) {
-                    return true;
+                try {
+                    $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
+                    if ($existsStmt && $existsStmt->fetchAll()) {
+                        return true;
+                    }
+                } catch (\PDOException $e) {
+                    /* Table does not exist; proceed to CREATE TABLE below. */
+                    $this->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Table {$tableName} does not exist, creating: " . $e->getMessage());
                 }
                 $modelVersion= $this->xpdo->getModelVersion($className);
                 $tableMeta= $this->xpdo->getTableMeta($className);

--- a/src/xPDO/Om/pgsql/xPDOManager.php
+++ b/src/xPDO/Om/pgsql/xPDOManager.php
@@ -132,9 +132,14 @@ class xPDOManager extends \xPDO\Om\xPDOManager
             $instance= $this->xpdo->newObject($className);
             if ($instance) {
                 $tableName= $this->xpdo->getTableName($className);
-                $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
-                if ($existsStmt && $existsStmt->fetchAll()) {
-                    return true;
+                try {
+                    $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
+                    if ($existsStmt && $existsStmt->fetchAll()) {
+                        return true;
+                    }
+                } catch (\PDOException $e) {
+                    /* Table does not exist; proceed to CREATE TABLE below. */
+                    $this->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Table {$tableName} does not exist, creating: " . $e->getMessage());
                 }
                 $tableMeta= $this->xpdo->getTableMeta($className);
                 $sql= 'CREATE TABLE ' . $tableName . ' (';

--- a/src/xPDO/Om/sqlite/xPDOManager.php
+++ b/src/xPDO/Om/sqlite/xPDOManager.php
@@ -87,9 +87,14 @@ class xPDOManager extends \xPDO\Om\xPDOManager {
             $instance= $this->xpdo->newObject($className);
             if ($instance) {
                 $tableName= $this->xpdo->getTableName($className);
-                $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
-                if ($existsStmt && $existsStmt->fetchAll()) {
-                    return true;
+                try {
+                    $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
+                    if ($existsStmt && $existsStmt->fetchAll()) {
+                        return true;
+                    }
+                } catch (\PDOException $e) {
+                    /* Table does not exist; proceed to CREATE TABLE below. */
+                    $this->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Table {$tableName} does not exist, creating: " . $e->getMessage());
                 }
                 $tableMeta= $this->xpdo->getTableMeta($className);
                 $sql= 'CREATE TABLE ' . $tableName . ' (';

--- a/src/xPDO/Om/sqlsrv/xPDOManager.php
+++ b/src/xPDO/Om/sqlsrv/xPDOManager.php
@@ -109,9 +109,14 @@ class xPDOManager extends \xPDO\Om\xPDOManager {
             $instance= $this->xpdo->newObject($className);
             if ($instance) {
                 $tableName= $this->xpdo->getTableName($className);
-                $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
-                if ($existsStmt && $existsStmt->fetchAll()) {
-                    return true;
+                try {
+                    $existsStmt = $this->xpdo->query("SELECT COUNT(*) FROM {$tableName}");
+                    if ($existsStmt && $existsStmt->fetchAll()) {
+                        return true;
+                    }
+                } catch (\PDOException $e) {
+                    /* Table does not exist; proceed to CREATE TABLE below. */
+                    $this->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Table {$tableName} does not exist, creating: " . $e->getMessage());
                 }
                 $tableMeta= $this->xpdo->getTableMeta($className);
                 $sql= 'CREATE TABLE ' . $tableName . ' (';

--- a/test/complete.phpunit.xml
+++ b/test/complete.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Om/xPDOQueryLimitTest.php</file>
             <file>./xPDO/Test/Om/xPDOQuerySortByTest.php</file>
             <file>./xPDO/Test/Om/xPDOGeneratorTest.php</file>
+            <file>./xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheManagerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>

--- a/test/mysql.phpunit.xml
+++ b/test/mysql.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Om/xPDOQueryLimitTest.php</file>
             <file>./xPDO/Test/Om/xPDOQuerySortByTest.php</file>
             <file>./xPDO/Test/Om/xPDOGeneratorTest.php</file>
+            <file>./xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheManagerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>

--- a/test/pgsql.phpunit.xml
+++ b/test/pgsql.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Om/xPDOQueryLimitTest.php</file>
             <file>./xPDO/Test/Om/xPDOQuerySortByTest.php</file>
             <file>./xPDO/Test/Om/xPDOGeneratorTest.php</file>
+            <file>./xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheManagerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>

--- a/test/sqlite.phpunit.xml
+++ b/test/sqlite.phpunit.xml
@@ -29,6 +29,7 @@
             <file>./xPDO/Test/Om/xPDOQueryLimitTest.php</file>
             <file>./xPDO/Test/Om/xPDOQuerySortByTest.php</file>
             <file>./xPDO/Test/Om/xPDOGeneratorTest.php</file>
+            <file>./xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheManagerTest.php</file>
             <file>./xPDO/Test/Cache/xPDOCacheDbTest.php</file>
             <file>./xPDO/Test/Compression/xPDOZipTest.php</file>

--- a/test/xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php
+++ b/test/xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Om;
+
+use xPDO\TestCase;
+use xPDO\xPDO;
+
+/**
+ * Regression test for issue #207:
+ * xPDOManager->createObjectContainer() broken in MySQL 8+ (and other drivers)
+ * when the table does not yet exist.
+ *
+ * Prior to the fix, calling createObjectContainer() on a non-existent table
+ * would cause an uncaught PDOException on drivers that raise errors as
+ * exceptions (ERRMODE_EXCEPTION). The fix wraps the existence probe in a
+ * try/catch so that a missing table causes the method to proceed with
+ * CREATE TABLE rather than propagating an exception.
+ *
+ * @package xPDO\Test\Om
+ */
+class xPDOManagerCreateObjectContainerTest extends TestCase
+{
+    /**
+     * Set up for each test: ensure the test table does NOT exist beforehand
+     * so we exercise the "table missing" code path in createObjectContainer().
+     *
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->xpdo->getManager();
+        // Drop the table if it already exists so each test starts clean.
+        try {
+            $this->xpdo->exec(
+                'DROP TABLE IF EXISTS ' . $this->xpdo->getTableName('xPDO\\Test\\Sample\\Person')
+            );
+        } catch (\PDOException $e) {
+            // Ignore; the table may not exist yet.
+        }
+    }
+
+    /**
+     * Tear down after each test: remove the created table.
+     *
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        try {
+            $this->xpdo->exec(
+                'DROP TABLE IF EXISTS ' . $this->xpdo->getTableName('xPDO\\Test\\Sample\\Person')
+            );
+        } catch (\PDOException $e) {
+            // Ignore.
+        }
+        parent::tearDownFixtures();
+    }
+
+    /**
+     * Verify createObjectContainer() returns true and does not throw when the
+     * table does not yet exist.
+     *
+     * Regression: on MySQL 8+ (and any driver in ERRMODE_EXCEPTION mode) the
+     * SELECT COUNT(*) existence probe threw an uncaught PDOException instead of
+     * proceeding to CREATE TABLE.
+     */
+    public function testCreateObjectContainerOnNonExistentTableReturnsTrue()
+    {
+        $this->xpdo->getManager();
+
+        // Force ERRMODE_EXCEPTION on the underlying PDO connection to reproduce
+        // the MySQL 8+ behaviour that triggered the bug.
+        if ($this->xpdo->pdo instanceof \PDO) {
+            $this->xpdo->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        }
+
+        $threwException = false;
+        $result = false;
+        try {
+            $result = $this->xpdo->manager->createObjectContainer('xPDO\\Test\\Sample\\Person');
+        } catch (\PDOException $e) {
+            $threwException = true;
+        }
+
+        $this->assertFalse(
+            $threwException,
+            'createObjectContainer() must not propagate a PDOException when the table does not yet exist (#207).'
+        );
+        $this->assertTrue(
+            $result,
+            'createObjectContainer() must return true after successfully creating the table.'
+        );
+    }
+
+    /**
+     * Verify createObjectContainer() returns true (idempotent) when the table
+     * already exists, and does not throw.
+     */
+    public function testCreateObjectContainerOnExistingTableReturnsTrue()
+    {
+        $this->xpdo->getManager();
+
+        // Create the table first.
+        $this->xpdo->manager->createObjectContainer('xPDO\\Test\\Sample\\Person');
+
+        // Calling a second time must return true without exception.
+        $threwException = false;
+        $result = false;
+        try {
+            $result = $this->xpdo->manager->createObjectContainer('xPDO\\Test\\Sample\\Person');
+        } catch (\PDOException $e) {
+            $threwException = true;
+        }
+
+        $this->assertFalse(
+            $threwException,
+            'createObjectContainer() must not throw when called on an already-existing table.'
+        );
+        $this->assertTrue(
+            $result,
+            'createObjectContainer() must return true when the table already exists (idempotent).'
+        );
+    }
+}


### PR DESCRIPTION
## What changed and why

The `createObjectContainer()` method in all four driver managers probes for table existence with a bare `SELECT COUNT(*) FROM {table}`. On MySQL 8+ (and any driver configured with `PDO::ERRMODE_EXCEPTION`), this query throws a `PDOException` when the table does not yet exist. The exception was not caught, causing the method to abort instead of proceeding to `CREATE TABLE`. Closes #207.

## Files and methods changed

- `src/xPDO/Om/mysql/xPDOManager.php` — `createObjectContainer()`: wrap existence probe in try/catch
- `src/xPDO/Om/pgsql/xPDOManager.php` — `createObjectContainer()`: same
- `src/xPDO/Om/sqlite/xPDOManager.php` — `createObjectContainer()`: same
- `src/xPDO/Om/sqlsrv/xPDOManager.php` — `createObjectContainer()`: same

## Cross-driver impact

All four drivers (MySQL, PostgreSQL, SQLite, SQL Server) contained the identical bug. All four are fixed identically.

## Test coverage

Added `test/xPDO/Test/Om/xPDOManagerCreateObjectContainerTest.php` with two test methods:

- `testCreateObjectContainerOnNonExistentTableReturnsTrue` — primary regression test; forces ERRMODE_EXCEPTION and verifies no PDOException propagates when table is absent
- `testCreateObjectContainerOnExistingTableReturnsTrue` — idempotency test; verifies the existing-table early-return path still works

Tests run against all CI drivers (SQLite, MySQL, PostgreSQL).

## Breaking change assessment

No public API signature or return type changed. The method already returned `bool`. When a table is absent the method previously threw; now it correctly proceeds to CREATE TABLE and returns `true` on success. Safe for patch-level consumers.

## AI Disclosure

This fix was developed using an AI-assisted workflow. AI agents (Claude) wrote the code, tests, and initial code review under the direction of the project maintainer (@opengeek), who reviewed the final diff, validated the approach, and takes responsibility for the submission.

## Contributors

Reported by the issue author. Community comment by @wshawn provided additional context.