### PR TITLE
Update symfony/console constraint to ^6.0|^7.0 and PHP minimum to >=8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -114,7 +114,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "ext-PDO": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/console": "^5.4",
+        "symfony/console": "^6.0|^7.0",
         "psr/container": "^1.1 || ^2.0.1",
         "psr/log": "^1.1 || ^2.0 || ^3.0"
     },


### PR DESCRIPTION
## What changed and why

The `composer.json` declared `"symfony/console": "^5.4"`, blocking consumers who require symfony/console 6 or 7 alongside modern tooling. I believe it is safe to bump the project's actual PHP minimum is 8.1 at this point with MODX Revolution 3.2 bumping to 8.1 already. This satisfies the requirements for symfony/console 6.x (PHP 8.0+) and 7.x (PHP 8.1+). Closes #180.

All console command code was reviewed and is fully compatible with symfony/console 6.x and 7.x — no code changes required beyond the version constraint.

## Files and methods changed

- `composer.json` — `symfony/console`: `"^5.4"` → `"^6.0|^7.0"`, `php`: `">=7.2.5"` → `">=8.1"`

## Cross-driver impact

Not applicable. This change affects the Composer dependency manifest only.

## Test coverage

No new tests added. The existing test suite validates that console commands continue to work correctly under the updated symfony/console version.

## Breaking change assessment

Bumping the PHP minimum to `>=8.1` removes support for PHP 7.x and 8.0. This is an alignment with the MODX 3.2's new documented minimum rather than a new restriction. The symfony/console 5.x support is dropped. Not safe for minor-level consumers who are on PHP <8.1 or symfony/console <6.0.

## AI Disclosure

This fix was developed using an AI-assisted workflow. AI agents (Claude) wrote the code, tests, and initial code review under the direction of the project maintainer (@opengeek), who reviewed the final diff, validated the approach, and takes responsibility for the submission.

## Contributors

Reported by @sdrenth, @joeke, @smaddock, @JoshuaLuckers. Additional compatibility note by @smaddock (June 2025).