### PR TITLE
Upgrade CI database images: MySQL 5.6 → 8.0, PostgreSQL 9.6 → 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     services:
       mysql:
-        image: "mysql:5.6"
+        image: "mysql:8.0"
 
         options: >-
           --health-cmd "mysqladmin ping --silent"
@@ -101,7 +101,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:16
 
         env:
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## What changed and why

The CI matrix was testing against MySQL 5.6 and PostgreSQL 9.6, both of which reached EOL in 2021. Neither is a valid test target for xPDO 3.2's PHP 8.1 minimum — MySQL 5.6 + PHP 8.x is not a supported or tested configuration upstream.

More critically, the MySQL 5.6 CI job was actively masking real regressions:
- Issue #207 (`createObjectContainer()` PDOException) only surfaces on MySQL 8+ where `ERRMODE_EXCEPTION` is the effective default
- Issue #190 (GROUP BY `ONLY_FULL_GROUP_BY`) triggers on MySQL 5.7+, not caught by a 5.6 job

Upgrading to MySQL 8.0 and PostgreSQL 16 makes the CI suite honest about the environments xPDO 3.2 is actually targeting.

## Files and methods changed

- `.github/workflows/ci.yml` — `mysql` service image: `mysql:5.6` → `mysql:8.0`
- `.github/workflows/ci.yml` — `postgres` service image: `postgres:9.6` → `postgres:16`

## Cross-driver impact

CI hardening only. No xPDO source code changed.

## Test coverage

No new tests. Existing MySQL and PostgreSQL test suites now run against current-generation database images.

## Breaking change assessment

No public API change. This is a CI infrastructure update. Consumers running their own test suites against MySQL 5.6 or PostgreSQL 9.6 are unaffected by this change.

## AI Disclosure

This PR was developed using an AI-assisted workflow. The actual configuration change — swapping two database image tags in `.github/workflows/ci.yml` — was straightforward; the substantive AI contribution was the analysis: identifying that the EOL database images were masking real regressions (#190, #207), confirming that MySQL 8.0 and PostgreSQL 16 are appropriate replacement targets, and drafting the PR description. @opengeek reviewed the analysis, validated the image choices, applied the change, and takes responsibility for the submission.

No tests were written (none applicable to a CI infrastructure change). No source code was written by AI.

## Contributors

No external contributors associated.