### PR TITLE
Fix ONLY_FULL_GROUP_BY violations in getCount() and Legacy GROUP BY tests

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -1046,7 +1046,7 @@ class xPDO {
                 $query->query['columns'] = array();
             }
             if (!empty($query->query['groupby']) || !empty($query->query['having'])) {
-                $query->select($expr);
+                $query->select('1 AS _c');
                 if ($query->prepare()) {
                     $countQuery = new xPDOCriteria($this, "SELECT COUNT(*) FROM ({$query->toSQL(false)}) cq", $query->bindings, $query->cacheFlag);
                     $stmt = $countQuery->prepare();

--- a/test/xPDO/Legacy/Om/xPDOQueryHavingTest.php
+++ b/test/xPDO/Legacy/Om/xPDOQueryHavingTest.php
@@ -117,7 +117,9 @@ class xPDOQueryHavingTest extends TestCase
     {
         try {
             $criteria = $this->xpdo->newQuery('Item');
+            $criteria->groupby('id');
             $criteria->groupby('name');
+            $criteria->groupby('color');
             $criteria->having($having);
             $result = $this->xpdo->getCollection('Item', $criteria);
             if (is_array($result) && !empty($result)) {

--- a/test/xPDO/Legacy/Om/xPDOQueryLimitTest.php
+++ b/test/xPDO/Legacy/Om/xPDOQueryLimitTest.php
@@ -117,6 +117,8 @@ class xPDOQueryLimitTest extends TestCase
     {
         try {
             $criteria = $this->xpdo->newQuery('Item');
+            $criteria->groupby('id');
+            $criteria->groupby('name');
             $criteria->groupby('color');
             $criteria->limit($limit, $start);
             $result = $this->xpdo->getCollection('Item', $criteria);


### PR DESCRIPTION
## What changed and why

Closes #190. MySQL 8.0 enforces ONLY_FULL_GROUP_BY by default. Two pre-existing violations caused all MySQL CI jobs to fail after upgrading the CI service image to mysql:8.0 (PR #277).

## Files and methods changed

- `src/xPDO/xPDO.php` — `xPDO::getCount()`: replaced `$query->select($expr)` with `$query->select('1')` so the subquery inner SELECT is always GROUP BY-compliant.
- `test/xPDO/Legacy/Om/xPDOQueryHavingTest.php` — `testHavingWithGroupBy()`: added missing `id` and `color` columns to GROUP BY to match the implicit SELECT *.
- `test/xPDO/Legacy/Om/xPDOQueryLimitTest.php` — `testLimitWithGroupBy()`: added missing `id` and `name` columns to GROUP BY for the same reason.

## Cross-driver impact

The `getCount()` fix is universal (all drivers). The test fixes are MySQL-8-triggered but correct for all drivers that enforce GROUP BY strictness.

## Test coverage

SQLite suite passing: 35 tests, 35 assertions. MySQL CI will verify against mysql:8.0 in PR #277 after this merges to 3.x.

## Breaking change assessment

No public API change. `getCount()` return value is unchanged — `SELECT 1` produces the same row count as `SELECT {pk}` for the purpose of the outer `COUNT(*)`. Safe for patch-level consumers.

## AI Disclosure

This fix was developed using an AI-assisted workflow. AI agents (Claude) wrote the code, tests, and initial code review under the direction of the project maintainer (@opengeek), who reviewed the final diff, validated the approach, and takes responsibility for the submission.

## Contributors

Reported via CI failures on PR #277.