### PR TITLE
Throw xPDOException when ContainerInterface lacks required 'config' entry

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -369,6 +369,8 @@ class xPDO {
             $this->services = $data;
             if ($this->services->has('config')) {
                 $data = $this->services->get('config');
+            } else {
+                throw new xPDOException('A ContainerInterface passed to xPDO must provide a \'config\' entry containing the xPDO configuration array.');
             }
         }
         if (!is_array($data)) {

--- a/test/complete.phpunit.xml
+++ b/test/complete.phpunit.xml
@@ -34,6 +34,7 @@
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
+            <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
         <testsuite name="Legacy">

--- a/test/mysql.phpunit.xml
+++ b/test/mysql.phpunit.xml
@@ -34,6 +34,7 @@
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
+            <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
         <testsuite name="Legacy">

--- a/test/pgsql.phpunit.xml
+++ b/test/pgsql.phpunit.xml
@@ -34,6 +34,7 @@
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
+            <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
     </testsuites>

--- a/test/sqlite.phpunit.xml
+++ b/test/sqlite.phpunit.xml
@@ -34,6 +34,7 @@
             <file>./xPDO/Test/Transport/xPDOTransportTest.php</file>
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
+            <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
         <testsuite name="Legacy">

--- a/test/xPDO/Test/xPDOPsr11InitTest.php
+++ b/test/xPDO/Test/xPDOPsr11InitTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test;
+
+use PHPUnit\Framework\TestCase;
+use xPDO\xPDO;
+use xPDO\xPDOContainer;
+use xPDO\xPDOException;
+
+/**
+ * Tests for PSR-11 container initialization contract (issue #269).
+ *
+ * These tests verify that passing a ContainerInterface to xPDO makes the
+ * required 'config' entry contract explicit rather than silently falling back
+ * to default values when it is missing.
+ *
+ * @package xPDO\Test
+ */
+class xPDOPsr11InitTest extends TestCase
+{
+    /**
+     * Passing a container without a 'config' entry must throw xPDOException.
+     *
+     * Before the fix, xPDO would silently fall back to an empty config array
+     * when the container did not provide a 'config' entry, hiding the broken
+     * API contract from the caller.
+     */
+    public function testContainerWithoutConfigEntryThrowsException(): void
+    {
+        $container = new xPDOContainer();
+        // Deliberately do NOT add a 'config' entry
+
+        $this->expectException(xPDOException::class);
+        $this->expectExceptionMessage('config');
+
+        new xPDO(null, '', '', $container);
+    }
+
+    /**
+     * Passing a container WITH a valid 'config' entry must initialize normally.
+     *
+     * This is the positive-path contract test: a container that provides the
+     * required 'config' entry must result in a fully initialised xPDO instance
+     * without throwing.
+     */
+    public function testContainerWithConfigEntryInitializesSuccessfully(): void
+    {
+        $properties = include __DIR__ . '/../../properties.inc.php';
+        $driver = getenv('TEST_DRIVER') ?: 'sqlite';
+        $config = $properties["{$driver}_array_options"];
+
+        $container = new xPDOContainer();
+        $container->add('config', $config);
+
+        $xpdo = new xPDO(null, '', '', $container);
+
+        $this->assertInstanceOf(xPDO::class, $xpdo);
+        $this->assertSame($container, $xpdo->services);
+    }
+}


### PR DESCRIPTION
## What changed and why

`xPDO::initConfig()` silently fell back to a minimal default config when a PSR-11 `ContainerInterface` was passed without a `'config'` entry, hiding the broken API contract from callers. The fix adds an explicit `xPDOException` in that case, making the required contract clear at construction time rather than producing mysterious runtime failures.

Closes #269.

## Files and methods changed

- `src/xPDO/xPDO.php` — `initConfig()`: add `else` branch throwing `xPDOException` when container lacks `'config'` entry.
- `test/xPDO/Test/xPDOPsr11InitTest.php` — new test file (2 test methods).
- `test/sqlite.phpunit.xml`, `test/mysql.phpunit.xml`, `test/pgsql.phpunit.xml`, `test/complete.phpunit.xml` — new test file registered in Complete testsuite.

## Cross-driver impact

Universal. `initConfig()` runs before any driver-specific code. All four driver configs updated.

## Test coverage

New: `test/xPDO/Test/xPDOPsr11InitTest.php` — 2 tests (regression + positive path).
Full suite (sqlite): Tests: 432, Assertions: 598, Skipped: 1 — zero failures.

## Breaking change assessment

Behavior change for callers passing a `ContainerInterface` without a `'config'` entry — they now receive an explicit exception instead of silent misconfiguration. Callers using the PSR-11 path correctly are unaffected. This is an intentional correction of a broken API contract, not introduced by design.

## AI Disclosure

This fix was developed using an AI-assisted workflow. AI agents (Claude) wrote tests, code, and performed initial code review under the direction of the project maintainer (@opengeek), who reviewed the final diff, validated the approach, and takes responsibility for the submission.

## Contributors

No external contributor. Follow-on from PR #265 (PSR-3 logger, merged 2026-03-08).