### PR TITLE
Add AI Contribution Policy

### DIFF
--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -1,0 +1,48 @@
+# AI Contribution Policy
+
+## Our position
+
+We welcome contributions from people who use AI tools. We do not welcome contributions from AI tools that use people as a submit button.
+
+If you understand what you are submitting, including why it works, what it changes, and how it interacts with the codebase, then how you got there is your business. If you are submitting output you cannot explain, defend, or take responsibility for, that is a problem regardless of how it was produced.
+
+The maintainers of this project use AI tools in their own work. The same authorship standard applies to them.
+
+## Before you submit
+
+The test is simple: can you understand it, can you stand behind it, and can you engage with review on your own? How many keystrokes were yours is irrelevant. A contribution produced mostly with AI assistance can pass it. A contribution written by hand can fail it.
+
+Be sure you:
+
+- have **read** the code you are submitting, not just skimmed it, and understand what it does, why it is structured the way it is, and how it fits the surrounding codebase.
+- have **validated** it: not just run it and saw no errors, but traced through the logic and satisfied yourself that it does what you are claiming.
+- have **made it yours.** If something in the output was wrong, generic, or mismatched to this project's architecture, you caught it and corrected it.
+- **can engage with review** in your own words. If a maintainer asks why you took a particular approach, you can answer without re-prompting a tool.
+
+## Disclosure
+
+When AI tools played a meaningful role in your contribution, say so in the PR description. Include appropriate specifics like what you used and how you used it.
+
+Disclosure is not a gate. It does not make a poor contribution acceptable or a strong one suspect. It is honest professional practice, and it helps maintainers calibrate their review. Concealing significant AI involvement when directly asked is considered a conduct issue.
+
+AI-assisted contributions remain subject to the same licensing terms as any other contribution to the project.
+
+## Maintainer discretion
+
+Maintainers may close contributions that do not meet this standard without detailed explanation. A link to this policy is a complete response. Resubmissions are welcome. Engage with the specific feedback, demonstrate your understanding, and reopen.
+
+## Consequences
+
+A single closed PR is not a permanent mark. Engage honestly and the door remains open.
+
+A first-instance closure comes with a link to this policy and a note on the specific shortcoming. A pattern of low-quality submissions may prompt a direct conversation and a temporary restriction at maintainer discretion. Submitting AI output at volume after being told not to, or misrepresenting the origin of a contribution when directly asked, is grounds for a permanent ban.
+
+## How this policy will evolve
+
+AI tooling changes quickly. This policy will be reviewed at least annually. Specific guidance will shift as tools mature and community norms settle. The core principle will not: the contributor is accountable for what they submit.
+
+Significant revisions will be announced through the project's community channels.
+
+---
+
+*This policy was last updated April 2026.*


### PR DESCRIPTION
## What changed and why

This PR adopts the AI Contribution Policy as a repo-visible document (`AI-POLICY.md`) at the project root.

## Files changed

- `AI-POLICY.md` (new file) — policy text only; no other files touched

## Compatibility impact

None. Documentation-only change.

## Test coverage

Not applicable.

## Breaking change assessment

None. No public API or behavior changes.

## AI Disclosure

This PR was prepared using an AI-assisted workflow. The policy text was drafted and revised by Claude Code agents under the direction of the project maintainer (@opengeek), who guided the development, approved the final content, and takes responsibility for the submission.