### PR TITLE
Make improvements to parseDSN method

### DIFF
--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2367,7 +2367,9 @@ class xPDO {
         foreach($params as $param) {
             $paramData = explode('=', $param);
             $key = strtolower($paramData[0]);
-            $result[$key] = $paramData[1];
+            if ($key) {
+                $result[$key] = $paramData[1];
+            }
         }
         
         if (!isset($result['dbname']) && isset($result['database'])) {

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2290,18 +2290,18 @@ class xPDO {
      * by latest native PDO implementation.
      */
     public static function parseDSN($string) {
-        $result= array ();
-        $pos= strpos($string, ':');
-        $result['dbtype']= strtolower(substr($string, 0, $pos));
-        $parameters= explode(';', substr($string, ($pos +1)));
-        for ($a= 0, $b= count($parameters); $a < $b; $a++) {
-            $tmp= explode('=', $parameters[$a]);
-            if (count($tmp) == 2) {
-                $result[strtolower(trim($tmp[0]))]= trim($tmp[1]);
-            } else {
-                $result['dbname']= trim($parameters[$a]);
-            }
+        $result = [];
+        $dsn = trim(preg_replace('/(\s*)([:;=])(\s*)/', '$2', $string), ' ;');
+        $tmp = explode(':', $dsn);
+        $result['dbtype'] = strtolower($tmp[0]);
+        $params = explode(';', $tmp[1]);
+        
+        foreach($params as $param) {
+            $paramData = explode('=', $param);
+            $key = strtolower($paramData[0]);
+            $result[$key] = $paramData[1];
         }
+        
         if (!isset($result['dbname']) && isset($result['database'])) {
             $result['dbname'] = $result['database'];
         }

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2368,7 +2368,7 @@ class xPDO {
             $paramData = explode('=', $param);
             $key = strtolower($paramData[0]);
             if ($key) {
-                $result[$key] = $paramData[1];
+                $result[$key] = $paramData[1] ?? '';
             }
         }
         

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2344,7 +2344,7 @@ class xPDO {
             }
 
         } else {
-            $tmp = explode(':', $dsn);
+            $tmp = explode(':', $dsn, 2);
             $paramsString = $tmp[1];
             $params = explode(';', $paramsString);
             $result['dbtype'] = strtolower($tmp[0]);

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2301,8 +2301,6 @@ class xPDO {
 
         if ($isSqlite) {
             $result['dbtype'] = 'sqlite';
-            // Name specified by dbname parameter takes precedence
-            $hasDbnameParam = stripos($dsn, 'dbname=') !== false;
             /*
                 Parse out the name based on the following:
 
@@ -2310,59 +2308,47 @@ class xPDO {
                 --------
                 1 - sqlite::memory:
                 2 - sqlite:file::memory:
-                3 - sqlite:file::memory:?cache=shared:
-                4 - sqlite:file:example1?mode=memory&cache=shared:
-                5 - sqlite:: (no name indicates temporary db)
+                3 - sqlite:file::memory:?cache=shared
+                4 - sqlite:file:example1?mode=memory&cache=shared
+                5 - sqlite:: (empty name indicates temporary db)
                 
                 File-based naming spec in dsn
                 ---------
-                6 - sqlite:example1.db:
-                
-                Unconventional way to spec db name for sqlite, but supported
-                7 - sqlite:dbname=example1.db&password=cx:0o!&username=joe@co.com
-
+                6 - sqlite:path/to/example1.db
             */
 
             $matches = null;
 
             // Note that the order of matching is important!
-            
-            if (preg_match('/(sqlite:file:)(?!:memory)([^:]*)?/s', $dsn, $matches)) {
-                // Captures in-memory format #4
+
+            if (substr_count($dsn, ':') === 1 && strlen($dsn) > 7) {
+                // Captures file-based format #6
+                $result['dbname'] = explode(':', $dsn)[1];
+            } else if (preg_match('/(sqlite:file:)(?!:memory)([^:]*)?/s', $dsn, $matches)) {
+                // Captures in-memory format #4; not handling errant extra colons around :file: (if found, dbname may just be 'file')
                 $result['dbname'] = $matches[0];
             } else if (preg_match('/(sqlite:file:|sqlite::)(:memory:\?[^:]*|:?memory:)?/s', $dsn, $matches)) {
                 // Captures in-memory formats #1-3, #5; empty string indicates temporary db
                 $result['dbname'] = $matches[0] === 'sqlite::' ? '' : $matches[0] ;
-            } else if (preg_match('/(sqlite:)([^:=]*)?:/s', $dsn, $matches)) {
-                // Captures file-based format #6
-                $result['dbname'] = rtrim($matches[0], ':');
             } else {
-                // Database name specified in dbname param (format #7) or is missing
-                if (!$hasDbnameParam) {
-                    // Trigger no db name specified error
-                }
-            }
-            
-            // Remove type and dbname to prepare for remaining params parsing
-            $find = !empty($matches) ? $matches[0] : 'sqlite:' ;
-            $paramsString = ltrim(str_replace($find, '', $dsn), ':');
-            
-            // Prioritizing dbname=X, when present, over matched name derived from beginning of dsn
-            if ($hasDbnameParam && isset($result['dbname'])) {
-                unset($result['dbname']);
+                self::log(xPDO::LOG_LEVEL_ERROR, "The given sqlite DSN connection string is either invalid or missing the correct specification of a database name: \r\n$string");
             }
             
             if (isset($result['dbname'])) {
                 $result['dbname'] = str_replace('sqlite:' , '', $result['dbname']);
+
+                // Remove errant colons (only dsns ending in :memory: without params should retain colon)
+                if (str_ends_with($result['dbname'], ':memory:') === false) {
+                    $result['dbname'] = trim($result['dbname'], ':');
+                }
             }
 
         } else {
             $tmp = explode(':', $dsn);
             $paramsString = $tmp[1];
+            $params = explode(';', $paramsString);
             $result['dbtype'] = strtolower($tmp[0]);
         }
-
-        $params = explode(';', $paramsString);
         
         foreach($params as $param) {
             $paramData = explode('=', $param);

--- a/src/xPDO/xPDO.php
+++ b/src/xPDO/xPDO.php
@@ -2290,11 +2290,79 @@ class xPDO {
      * by latest native PDO implementation.
      */
     public static function parseDSN($string) {
+        $paramsString = '';
+        $params = [];
         $result = [];
+
+        // Regex collapses all space except within values
         $dsn = trim(preg_replace('/(\s*)([:;=])(\s*)/', '$2', $string), ' ;');
-        $tmp = explode(':', $dsn);
-        $result['dbtype'] = strtolower($tmp[0]);
-        $params = explode(';', $tmp[1]);
+        
+        $isSqlite = stripos($dsn, 'sqlite:') === 0;
+
+        if ($isSqlite) {
+            $result['dbtype'] = 'sqlite';
+            // Name specified by dbname parameter takes precedence
+            $hasDbnameParam = stripos($dsn, 'dbname=') !== false;
+            /*
+                Parse out the name based on the following:
+
+                In-memory naming spec in dsn, including URI-based
+                --------
+                1 - sqlite::memory:
+                2 - sqlite:file::memory:
+                3 - sqlite:file::memory:?cache=shared:
+                4 - sqlite:file:example1?mode=memory&cache=shared:
+                5 - sqlite:: (no name indicates temporary db)
+                
+                File-based naming spec in dsn
+                ---------
+                6 - sqlite:example1.db:
+                
+                Unconventional way to spec db name for sqlite, but supported
+                7 - sqlite:dbname=example1.db&password=cx:0o!&username=joe@co.com
+
+            */
+
+            $matches = null;
+
+            // Note that the order of matching is important!
+            
+            if (preg_match('/(sqlite:file:)(?!:memory)([^:]*)?/s', $dsn, $matches)) {
+                // Captures in-memory format #4
+                $result['dbname'] = $matches[0];
+            } else if (preg_match('/(sqlite:file:|sqlite::)(:memory:\?[^:]*|:?memory:)?/s', $dsn, $matches)) {
+                // Captures in-memory formats #1-3, #5; empty string indicates temporary db
+                $result['dbname'] = $matches[0] === 'sqlite::' ? '' : $matches[0] ;
+            } else if (preg_match('/(sqlite:)([^:=]*)?:/s', $dsn, $matches)) {
+                // Captures file-based format #6
+                $result['dbname'] = rtrim($matches[0], ':');
+            } else {
+                // Database name specified in dbname param (format #7) or is missing
+                if (!$hasDbnameParam) {
+                    // Trigger no db name specified error
+                }
+            }
+            
+            // Remove type and dbname to prepare for remaining params parsing
+            $find = !empty($matches) ? $matches[0] : 'sqlite:' ;
+            $paramsString = ltrim(str_replace($find, '', $dsn), ':');
+            
+            // Prioritizing dbname=X, when present, over matched name derived from beginning of dsn
+            if ($hasDbnameParam && isset($result['dbname'])) {
+                unset($result['dbname']);
+            }
+            
+            if (isset($result['dbname'])) {
+                $result['dbname'] = str_replace('sqlite:' , '', $result['dbname']);
+            }
+
+        } else {
+            $tmp = explode(':', $dsn);
+            $paramsString = $tmp[1];
+            $result['dbtype'] = strtolower($tmp[0]);
+        }
+
+        $params = explode(';', $paramsString);
         
         foreach($params as $param) {
             $paramData = explode('=', $param);


### PR DESCRIPTION
Refactors the `parseDSN` method to simplify logic and prevent issues with trailing semi-colons in evaluated string. There was an [edge case](https://github.com/modxcms/revolution/issues/14976) in MODX where a trailing semi caused the `dbname` to be blank when it was, in fact, present in the string being evaluated.