### PR TITLE
feat: add ledger-backed database migrations and migrate-* CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ xPDO can be installed in your project via composer:
     composer require xpdo/xpdo
 
 
+## Database migrations
+
+Ledger-backed migrations: namespace `xPDO\Migrations\`, commands `migrate-create`, `migrate-status`, `migrate`, `migrate-rollback`. See [`docs/migrations/cli.md`](docs/migrations/cli.md).
+
 ## Usage
 
 The `\xPDO\xPDO` class is the main point of access to the framework. Provide a configuration array describing the connection(s) you want to establish when creating an instance of the class.

--- a/docs/migrations/cli.md
+++ b/docs/migrations/cli.md
@@ -1,0 +1,54 @@
+# xPDO Migrations: CLI reference
+
+Same binary as `parse-schema` / `write-schema`:
+
+```bash
+php bin/xpdo <command> [options]
+```
+
+Command names use hyphens (`migrate-create`). There is no `migration:*` Symfony namespace.
+
+## Shared options
+
+| Option | Meaning |
+|--------|---------|
+| `--config` / `-C` | Properties file (`Command::loadConfig`) |
+| `--platform` | `mysql`, `sqlite`, `pgsql`, or `sqlsrv` (default: `xpdo_driver` in config) |
+| `--path` | Override `migrations_path` |
+| `--namespace` | Override `migrations_namespace` |
+| `--table` | Override `migrations_table` |
+
+Config needs `{platform}_array_options`, plus `migrations_path` and `migrations_namespace` unless you pass CLI overrides.
+
+Exit codes: `0` success, `1` failure. Commands return Symfony status codes; they do not call `exit()`. Stack traces appear only with `-v` / `-vv` / `-vvv`.
+
+## Commands
+
+### `migrate-create`
+
+```bash
+php bin/xpdo migrate-create CreateWidgetTable -C path/to/properties.inc.php --platform=sqlite
+```
+
+- Description must match `[A-Za-z][A-Za-z0-9]*` after non-alphanumerics are stripped.
+- Writes `{YYYYMMDDHHMMSS_Description}.php` with class `M{name}` in the configured namespace.
+- Refuses overwrite (exclusive create; timestamp moves forward on collision).
+
+### `migrate-status`
+
+Reads ledger state. Does not create the repository table.
+
+- `Repository: missing` if the ledger table is absent.
+- Otherwise prints Applied, Pending, and Orphaned (ledger rows with no file) when present.
+
+### `migrate`
+
+Runs pending migrations in ascending name order. Optional `--step=N`.
+
+### `migrate-rollback`
+
+Reverts `MAX(batch)` in descending version order. Optional `--step=N` caps how many of those rows to reverse.
+
+## CI
+
+Commands take no prompts. Pass `--config` and `--platform` (or set `xpdo_driver` in properties).

--- a/docs/migrations/cli.md
+++ b/docs/migrations/cli.md
@@ -1,80 +1,228 @@
 # xPDO Migrations: CLI reference
 
-Same binary as `parse-schema` / `write-schema`:
+Ledger-backed database migrations for xPDO 3.x. You run them through the same `bin/xpdo` binary as `parse-schema` and `write-schema`.
 
 ```bash
 php bin/xpdo <command> [options]
 ```
 
-Command names use hyphens (`migrate-create`). There is no `migration:*` Symfony namespace.
+Command names use hyphens: `migrate-create`, `migrate-status`, `migrate`, `migrate-rollback`. There is no `migration:*` Symfony namespace.
 
-## Shared options
+Drivers covered by CI and this tooling: **mysql**, **pgsql**, **sqlite**. `sqlsrv` is listed on `--platform` like other Console commands, but migrations are not a sqlsrv CI gate.
+
+## Quick start
+
+```bash
+# 1. Point a properties file at your DB + migrations directory
+# 2. Scaffold a stub
+php bin/xpdo migrate-create CreateWidgetTable \
+  -C path/to/properties.inc.php --platform=sqlite
+
+# 3. Edit the generated file: implement up() / down()
+
+# 4. Inspect ledger vs files
+php bin/xpdo migrate-status \
+  -C path/to/properties.inc.php --platform=sqlite
+
+# 5. Apply pending
+php bin/xpdo migrate \
+  -C path/to/properties.inc.php --platform=sqlite
+
+# 6. Reverse the last batch if needed
+php bin/xpdo migrate-rollback \
+  -C path/to/properties.inc.php --platform=sqlite
+```
+
+Commit migration PHP files to Git with your application. The ledger table lives in the database; do not invent ledger rows by hand.
+
+## Configuration
+
+Commands load a PHP properties file the same way other xPDO Console commands do (`--config` / `-C`, or the usual discovery for `properties.inc.php`).
+
+You need:
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `{platform}_array_options` | yes | xPDO connection options for that platform (same shape as schema tools) |
+| `migrations_path` | yes* | Local directory for `*.php` migration files |
+| `migrations_namespace` | yes* | PHP namespace for generated classes |
+| `xpdo_driver` | optional | Default platform when `--platform` is omitted |
+| `migrations_table` | optional | Ledger table name (default `xpdo_migrations`) |
+| `transaction_policy` | optional | `non_transactional` (default) or `transactional` |
+| `migrations_lock_name` | optional | Extra salt for the migrate lock key |
+
+\* Required unless you pass `--path` / `--namespace` on the CLI.
+
+Example keys (also commented in `test/properties.sample.inc.php`):
+
+```php
+$properties['migrations_path'] = __DIR__ . '/migrations';
+$properties['migrations_namespace'] = 'App\\Migrations';
+// $properties['migrations_table'] = 'xpdo_migrations';
+// $properties['transaction_policy'] = 'non_transactional';
+```
+
+Map the namespace to the path in Composer PSR-4, or rely on the runner `require`-ing each file once. Paths must be local filesystem paths (no `http://`, `phar://`, …). Table and lock names must match `^[A-Za-z_][A-Za-z0-9_]*$`.
+
+### Shared CLI options
 
 | Option | Meaning |
 |--------|---------|
-| `--config` / `-C` | Properties file (`Command::loadConfig`) |
-| `--platform` | `mysql`, `sqlite`, `pgsql`, or `sqlsrv` (default: `xpdo_driver` in config) |
+| `--config` / `-C` | Properties file |
+| `--platform` | `mysql`, `sqlite`, `pgsql`, or `sqlsrv` (falls back to `xpdo_driver`) |
 | `--path` | Override `migrations_path` |
 | `--namespace` | Override `migrations_namespace` |
 | `--table` | Override `migrations_table` |
 
-Config needs `{platform}_array_options`, plus `migrations_path` and `migrations_namespace` unless you pass CLI overrides.
+`migrate` and `migrate-rollback` also accept `--step=N` (positive integer). Invalid `--step` exits `1`.
 
-Optional config keys: `migrations_table` (default `xpdo_migrations`), `transaction_policy` (`non_transactional` default, or `transactional`), `migrations_lock_name`.
+### Exit codes and verbosity
 
-Exit codes: `0` success, `1` failure. Commands return Symfony status codes; they do not call `exit()`. Stack traces appear only with `-v` / `-vv` / `-vvv`.
+| Code | Meaning |
+|------|---------|
+| `0` | Success (`Command::SUCCESS`) |
+| `1` | Failure (`Command::FAILURE`) |
 
-## Identity and ordering
+Commands return Symfony status codes. They do not call `exit()`. Fatal lines print as `fatal: …`. With `-v` / `-vv` / `-vvv` you also get a stack trace. No interactive prompts: safe for CI.
 
-- Migration identity = filename stem matching `YYYYMMDDHHMMSS_Description` (UTC timestamp + description).
-- Class name = `M{stem}` in the configured namespace.
-- Ledger column `version` stores that stem. It is UNIQUE.
-- Pending runs in ascending name order. Rollback of a batch runs descending.
+## Identity, discovery, ledger
+
+**Identity** = migration name = filename stem:
+
+```text
+YYYYMMDDHHMMSS_Description
+```
+
+Example: `20260814120000_CreateWidgetTable`.
+
+| Artifact | Value |
+|----------|--------|
+| File | `{name}.php` under `migrations_path` |
+| Class | `{namespace}\M{name}` (prefix `M` + full stem) |
+| Ledger `version` | same stem, `UNIQUE`, max 191 chars |
+
+Discovery only loads `*.php` files matching `^[0-9]{14}_[A-Za-z][A-Za-z0-9]*$`. Other PHP files and subdirectories are ignored. Duplicate names, missing classes, or classes that do not extend `Migration` fail the command.
+
+**Ordering:** pending apply ascending by name. Rollback within a batch runs descending by name. The 14-digit UTC timestamp prefix is the ordering signal.
+
+**Ledger** (default table `xpdo_migrations`): `id`, `version`, `batch`, `applied_at` (UTC). A row means “applied”. No row + file present means “pending”. A row without a file is **orphaned** (shown by `migrate-status`; rollback of that version fails until you restore the file).
 
 ## Commands
 
 ### `migrate-create`
 
 ```bash
-php bin/xpdo migrate-create CreateWidgetTable -C path/to/properties.inc.php --platform=sqlite
+php bin/xpdo migrate-create CreateWidgetTable \
+  -C path/to/properties.inc.php --platform=sqlite \
+  --path=./migrations --namespace='App\Migrations'
 ```
 
-- Description must match `[A-Za-z][A-Za-z0-9]*` after non-alphanumerics are stripped.
-- Writes `{YYYYMMDDHHMMSS_Description}.php` with class `M{name}` in the configured namespace.
-- Refuses overwrite (exclusive create; timestamp moves forward on collision).
+- Argument `description`: non-alphanumerics stripped; remainder must match `[A-Za-z][A-Za-z0-9]*`.
+- Writes a stub with `up()` / `down()` (`down()` throws `IrreversibleMigrationException` until you implement it).
+- Creates the file with exclusive open (`fopen(..., 'x')`). Same-second collisions bump the timestamp forward instead of overwriting.
+- Does **not** need a live database connection.
+
+On success the CLI prints the created path/name. Commit the new file before you rely on other environments applying it.
 
 ### `migrate-status`
 
-Reads ledger state. Does not create the repository table.
+```bash
+php bin/xpdo migrate-status -C path/to/properties.inc.php --platform=sqlite
+```
 
-- `Repository: missing` if the ledger table is absent.
-- Otherwise prints Applied, Pending, and Orphaned (ledger rows with no file) when present.
+Read-only. Does **not** create the ledger table.
+
+| Output | Meaning |
+|--------|---------|
+| `Repository: missing` | No ledger table yet. Applied/pending unknown until first `migrate`. |
+| `Repository: ok` | Lists Applied, Pending, and Orphaned when present. |
+
+Orphans print a warning: restore missing files before `migrate` / `migrate-rollback`. Exit code is still `0` for a successful status read.
 
 ### `migrate`
 
-Runs pending migrations in ascending name order. Optional `--step=N`.
+```bash
+php bin/xpdo migrate -C path/to/properties.inc.php --platform=sqlite
+php bin/xpdo migrate --step=1 -C path/to/properties.inc.php --platform=sqlite
+```
 
-Creates the ledger table if needed. Failed `up()` is not recorded; later pending in that run are skipped. Re-run `migrate` after fixing.
+1. Acquires the migrate lock.
+2. Creates the ledger table if needed.
+3. Discovers files, computes pending.
+4. Assigns one **batch** id for this run (`MAX(batch)+1`) when there is work.
+5. Runs each pending `up()` in ascending name order (honors `--step`).
+6. Inserts a ledger row only after that `up()` returns.
+7. Releases the lock.
+
+Output examples:
+
+- `Nothing to migrate.`
+- `Applied batch 3:` then a bullet list; if more remain, `Still pending:`.
+
+**Failure:** the failed version is not recorded. Later pending in the same invocation are not run. Earlier successes in that batch stay applied (partial batch). Fix the migration and run `migrate` again. To undo a partial batch, run `migrate-rollback` (it targets `MAX(batch)`, which is that partial batch if it is latest).
 
 ### `migrate-rollback`
 
-Reverts `MAX(batch)` in descending version order. Optional `--step=N` caps how many of those rows to reverse.
+```bash
+php bin/xpdo migrate-rollback -C path/to/properties.inc.php --platform=sqlite
+php bin/xpdo migrate-rollback --step=1 -C path/to/properties.inc.php --platform=sqlite
+```
 
-Missing migration file or failed `down()` aborts and leaves that ledger row. Orphaned rows are never deleted silently.
+Reverses rows with `batch = MAX(batch)`, highest version first.
+
+Example: batch 2 has `C` then `D` applied. Default rollback runs `D` then `C`. `--step=1` runs only `D`. Batch 1 (`A`, `B`) is untouched until you roll back again after batch 2 is gone.
+
+| Case | Behavior |
+|------|----------|
+| Empty ledger / nothing to roll back | `Nothing to roll back.` exit `0` |
+| `down()` throws | Abort; that ledger row stays |
+| `IrreversibleMigrationException` | Abort; row stays |
+| Migration file missing (orphan) | Abort; row stays |
+
+No silent ledger deletes without a successful `down()`.
 
 ## Transactions
 
-Default `transaction_policy` is `non_transactional`: `up`/`down` run outside an outer transaction, then the ledger row is written. MySQL DDL often implicit-commits, so the default does not pretend DDL is atomic.
+Set `transaction_policy` in properties (or leave the default).
 
-With `transactional`, each migration wraps `up`/`down` + ledger write in one xPDO transaction. Prefer DML inside transactional migrations; treat MySQL DDL as non-atomic regardless.
+| Policy | Behavior |
+|--------|----------|
+| `non_transactional` (**default**) | Run `up`/`down`, then write the ledger. No outer transaction around both. |
+| `transactional` | One xPDO transaction per migration: `up`/`down` + ledger write, then commit. Errors roll back that transaction when the driver still has one open. |
 
-A crash after a successful `up()` but before the ledger insert (non-transactional) can leave schema changed and the version still pending. Fix manually; write idempotent `up()` where you can.
+Default is `non_transactional` because MySQL DDL often implicit-commits. A “transactional” migration that runs `CREATE TABLE` on MySQL still will not give you DDL atomicity. Prefer DML inside `transactional` migrations, or accept non-atomic DDL and write idempotent `up()` where you can.
+
+Crash window under the default: `up()` finished, process died before the ledger insert. Schema may already have changed while status still shows pending. Repair by hand, then re-run `migrate` (idempotent `up()` helps).
+
+Per-migration override: implement `isTransactional(): ?bool` on the class (`true` / `false` / `null` = use global config).
 
 ## Locks
 
-`migrate` / `migrate-rollback` take a fail-fast lock (MySQL `GET_LOCK`, PostgreSQL advisory lock, SQLite `flock` on a file under `migrations_path`). A second concurrent run fails instead of double-applying.
+`migrate` and `migrate-rollback` take a fail-fast lock so two processes do not apply the same version twice.
+
+| Driver | Mechanism |
+|--------|-----------|
+| mysql | `GET_LOCK` (timeout 0) |
+| pgsql | `pg_try_advisory_lock` |
+| sqlite | `flock` on `{migrations_path}/.xpdo_migration.lock` |
+
+A second run that cannot acquire the lock fails with a lock error. Locks are per database / table (and optional `migrations_lock_name`). SQLite’s file lock is not a distributed lock across NFS or unrelated hosts sharing one DB file carelessly.
+
+`migrate-status` and `migrate-create` do not take this lock.
+
+## Failure recovery cheat sheet
+
+| Situation | What you do |
+|-----------|-------------|
+| `up()` threw | Fix the PHP; run `migrate` again. Failed version was never recorded. |
+| Partial batch (A ok, B failed) | Fix B and `migrate`, or `migrate-rollback` to undo A if that batch is still `MAX(batch)`. |
+| `down()` threw | Fix `down()`; run `migrate-rollback` again. Row still present. |
+| Orphaned ledger row | Restore the file from Git (or history). Do not delete the row by hand unless you know the schema state. |
+| Rename file / change stem | Treated as a new identity. Old version becomes orphaned; new file is pending. Avoid renames after apply. |
 
 ## PHP API
+
+Same behavior without Console:
 
 ```php
 use xPDO\Migrations\MigrationConfig;
@@ -83,13 +231,24 @@ use xPDO\Migrations\Migrator;
 $migrator = new Migrator($xpdo, MigrationConfig::fromArray([
     'migrations_path' => __DIR__ . '/migrations',
     'migrations_namespace' => 'App\\Migrations',
+    // 'migrations_table' => 'xpdo_migrations',
+    // 'transaction_policy' => 'non_transactional',
 ]));
+
 $migrator->create('CreateWidgetTable');
-$migrator->status();
-$migrator->migrate();
-$migrator->rollback();
+$status = $migrator->status();   // MigratorResult
+$migrator->migrate();            // or migrate(1)
+$migrator->rollback();           // or rollback(1)
 ```
+
+Stable types for consumers: `Migrator`, `Migration`, `MigrationContext`, `MigrationConfig`, `MigratorResult`. Discoverer / repository / executor / lock are `@internal`.
 
 ## CI
 
-Commands take no prompts. Pass `--config` and `--platform` (or set `xpdo_driver` in properties).
+Pass `--config` and `--platform` (or set `xpdo_driver`). Example:
+
+```bash
+php bin/xpdo migrate -C deploy/properties.inc.php --platform=mysql
+```
+
+No prompts. Treat exit code `1` as a failed deploy step.

--- a/docs/migrations/cli.md
+++ b/docs/migrations/cli.md
@@ -20,7 +20,16 @@ Command names use hyphens (`migrate-create`). There is no `migration:*` Symfony 
 
 Config needs `{platform}_array_options`, plus `migrations_path` and `migrations_namespace` unless you pass CLI overrides.
 
+Optional config keys: `migrations_table` (default `xpdo_migrations`), `transaction_policy` (`non_transactional` default, or `transactional`), `migrations_lock_name`.
+
 Exit codes: `0` success, `1` failure. Commands return Symfony status codes; they do not call `exit()`. Stack traces appear only with `-v` / `-vv` / `-vvv`.
+
+## Identity and ordering
+
+- Migration identity = filename stem matching `YYYYMMDDHHMMSS_Description` (UTC timestamp + description).
+- Class name = `M{stem}` in the configured namespace.
+- Ledger column `version` stores that stem. It is UNIQUE.
+- Pending runs in ascending name order. Rollback of a batch runs descending.
 
 ## Commands
 
@@ -45,9 +54,41 @@ Reads ledger state. Does not create the repository table.
 
 Runs pending migrations in ascending name order. Optional `--step=N`.
 
+Creates the ledger table if needed. Failed `up()` is not recorded; later pending in that run are skipped. Re-run `migrate` after fixing.
+
 ### `migrate-rollback`
 
 Reverts `MAX(batch)` in descending version order. Optional `--step=N` caps how many of those rows to reverse.
+
+Missing migration file or failed `down()` aborts and leaves that ledger row. Orphaned rows are never deleted silently.
+
+## Transactions
+
+Default `transaction_policy` is `non_transactional`: `up`/`down` run outside an outer transaction, then the ledger row is written. MySQL DDL often implicit-commits, so the default does not pretend DDL is atomic.
+
+With `transactional`, each migration wraps `up`/`down` + ledger write in one xPDO transaction. Prefer DML inside transactional migrations; treat MySQL DDL as non-atomic regardless.
+
+A crash after a successful `up()` but before the ledger insert (non-transactional) can leave schema changed and the version still pending. Fix manually; write idempotent `up()` where you can.
+
+## Locks
+
+`migrate` / `migrate-rollback` take a fail-fast lock (MySQL `GET_LOCK`, PostgreSQL advisory lock, SQLite `flock` on a file under `migrations_path`). A second concurrent run fails instead of double-applying.
+
+## PHP API
+
+```php
+use xPDO\Migrations\MigrationConfig;
+use xPDO\Migrations\Migrator;
+
+$migrator = new Migrator($xpdo, MigrationConfig::fromArray([
+    'migrations_path' => __DIR__ . '/migrations',
+    'migrations_namespace' => 'App\\Migrations',
+]));
+$migrator->create('CreateWidgetTable');
+$migrator->status();
+$migrator->migrate();
+$migrator->rollback();
+```
 
 ## CI
 

--- a/src/xPDO/Console/Application.php
+++ b/src/xPDO/Console/Application.php
@@ -1,6 +1,10 @@
 <?php
 namespace xPDO\Console;
 
+use xPDO\Console\Command\Migrate;
+use xPDO\Console\Command\MigrateCreate;
+use xPDO\Console\Command\MigrateRollback;
+use xPDO\Console\Command\MigrateStatus;
 use xPDO\Console\Command\ParseSchema;
 use xPDO\Console\Command\WriteSchema;
 
@@ -17,5 +21,9 @@ class Application extends \Symfony\Component\Console\Application
     {
         $this->add(new ParseSchema());
         $this->add(new WriteSchema());
+        $this->add(new MigrateCreate());
+        $this->add(new MigrateStatus());
+        $this->add(new Migrate());
+        $this->add(new MigrateRollback());
     }
 }

--- a/src/xPDO/Console/Command/Command.php
+++ b/src/xPDO/Console/Command/Command.php
@@ -7,11 +7,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Command extends \Symfony\Component\Console\Command\Command
 {
     protected static $platforms = [
-        'mysql', 
-        'sqlite', 
-        'sqlsrv'
+        'mysql',
+        'sqlite',
+        'pgsql',
+        'sqlsrv',
     ];
-    
+
     protected function loadConfig(OutputInterface $output, $config = null)
     {
         if (empty($config) || !is_readable($config)) {
@@ -41,7 +42,7 @@ class Command extends \Symfony\Component\Console\Command\Command
             if ($output->getVerbosity() == OutputInterface::VERBOSITY_VERBOSE) {
                 $output->writeln("using config from {$config}");
             }
-            
+
             return $properties;
         }
 

--- a/src/xPDO/Console/Command/Migrate.php
+++ b/src/xPDO/Console/Command/Migrate.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class Migrate extends Command
+{
+    use MigrationConsoleTrait;
+
+    protected function configure()
+    {
+        $this
+            ->setName('migrate')
+            ->setDescription('Apply pending xPDO migrations')
+            ->addOption(
+                'step',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Apply at most N pending migrations'
+            )
+        ;
+        $this->addMigrationOptions();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $migrator = $this->createMigrator($input, $output);
+        if ($migrator === null) {
+            return Command::FAILURE;
+        }
+
+        $step = $this->parseStepOption($input, $output);
+        if ($step === 0) {
+            return Command::FAILURE;
+        }
+
+        try {
+            $result = $migrator->migrate($step);
+        } catch (Throwable $e) {
+            $this->writeThrowable($output, $e);
+            return Command::FAILURE;
+        }
+
+        if ($result->applied === []) {
+            $output->writeln('Nothing to migrate.');
+        } else {
+            $output->writeln('Applied batch ' . ($result->batch ?? '?') . ':');
+            $this->writeResultLines($output, $result->applied);
+        }
+        if ($result->pending !== []) {
+            $output->writeln('Still pending:');
+            $this->writeResultLines($output, $result->pending);
+        }
+        return Command::SUCCESS;
+    }
+}

--- a/src/xPDO/Console/Command/Migrate.php
+++ b/src/xPDO/Console/Command/Migrate.php
@@ -35,7 +35,7 @@ final class Migrate extends Command
         $this->addMigrationOptions();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $migrator = $this->createMigrator($input, $output);
         if ($migrator === null) {

--- a/src/xPDO/Console/Command/MigrateCreate.php
+++ b/src/xPDO/Console/Command/MigrateCreate.php
@@ -34,7 +34,7 @@ final class MigrateCreate extends Command
         $this->addMigrationOptions();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $migrator = $this->createMigrator($input, $output);
         if ($migrator === null) {

--- a/src/xPDO/Console/Command/MigrateCreate.php
+++ b/src/xPDO/Console/Command/MigrateCreate.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class MigrateCreate extends Command
+{
+    use MigrationConsoleTrait;
+
+    protected function configure()
+    {
+        $this
+            ->setName('migrate-create')
+            ->setDescription('Generate a new xPDO migration class skeleton')
+            ->addArgument(
+                'description',
+                InputArgument::REQUIRED,
+                'Migration description (letters/digits; used after the timestamp prefix)'
+            )
+        ;
+        $this->addMigrationOptions();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $migrator = $this->createMigrator($input, $output);
+        if ($migrator === null) {
+            return Command::FAILURE;
+        }
+
+        try {
+            $result = $migrator->create((string) $input->getArgument('description'));
+        } catch (Throwable $e) {
+            $this->writeThrowable($output, $e);
+            return Command::FAILURE;
+        }
+
+        foreach ($result->messages as $message) {
+            $output->writeln($message);
+        }
+        if ($result->created !== null) {
+            $output->writeln('Created migration: ' . $result->created);
+        }
+        return Command::SUCCESS;
+    }
+}

--- a/src/xPDO/Console/Command/MigrateRollback.php
+++ b/src/xPDO/Console/Command/MigrateRollback.php
@@ -35,7 +35,7 @@ final class MigrateRollback extends Command
         $this->addMigrationOptions();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $migrator = $this->createMigrator($input, $output);
         if ($migrator === null) {

--- a/src/xPDO/Console/Command/MigrateRollback.php
+++ b/src/xPDO/Console/Command/MigrateRollback.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class MigrateRollback extends Command
+{
+    use MigrationConsoleTrait;
+
+    protected function configure()
+    {
+        $this
+            ->setName('migrate-rollback')
+            ->setDescription('Roll back the last xPDO migration batch (or --step within that batch)')
+            ->addOption(
+                'step',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Roll back at most N migrations from the last batch (descending by version)'
+            )
+        ;
+        $this->addMigrationOptions();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $migrator = $this->createMigrator($input, $output);
+        if ($migrator === null) {
+            return Command::FAILURE;
+        }
+
+        $step = $this->parseStepOption($input, $output);
+        if ($step === 0) {
+            return Command::FAILURE;
+        }
+
+        try {
+            $result = $migrator->rollback($step);
+        } catch (Throwable $e) {
+            $this->writeThrowable($output, $e);
+            return Command::FAILURE;
+        }
+
+        if ($result->rolledBack === []) {
+            $output->writeln('Nothing to roll back.');
+        } else {
+            $output->writeln('Rolled back batch ' . ($result->batch ?? '?') . ':');
+            $this->writeResultLines($output, $result->rolledBack);
+        }
+        return Command::SUCCESS;
+    }
+}

--- a/src/xPDO/Console/Command/MigrateStatus.php
+++ b/src/xPDO/Console/Command/MigrateStatus.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use xPDO\Migrations\MigratorResult;
+
+final class MigrateStatus extends Command
+{
+    use MigrationConsoleTrait;
+
+    protected function configure()
+    {
+        $this
+            ->setName('migrate-status')
+            ->setDescription('Show applied and pending xPDO migrations (does not create the ledger)')
+        ;
+        $this->addMigrationOptions();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $migrator = $this->createMigrator($input, $output);
+        if ($migrator === null) {
+            return Command::FAILURE;
+        }
+
+        try {
+            $result = $migrator->status();
+        } catch (Throwable $e) {
+            $this->writeThrowable($output, $e);
+            return Command::FAILURE;
+        }
+
+        if ($result->repositoryState === MigratorResult::REPOSITORY_MISSING) {
+            $output->writeln('Repository: missing');
+            $output->writeln('Ledger table does not exist yet. Applied/pending are unknown until migrate runs.');
+            return Command::SUCCESS;
+        }
+
+        $output->writeln('Repository: ok');
+        $output->writeln('Applied:');
+        $this->writeResultLines($output, $result->applied);
+        $output->writeln('Pending:');
+        $this->writeResultLines($output, $result->pending);
+        if ($result->orphaned !== []) {
+            $output->writeln('Orphaned (ledger rows without migration files):');
+            $this->writeResultLines($output, $result->orphaned);
+            $output->writeln(
+                'warning: restore missing migration files before migrate/rollback'
+            );
+        }
+        return Command::SUCCESS;
+    }
+}

--- a/src/xPDO/Console/Command/MigrateStatus.php
+++ b/src/xPDO/Console/Command/MigrateStatus.php
@@ -29,7 +29,7 @@ final class MigrateStatus extends Command
         $this->addMigrationOptions();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $migrator = $this->createMigrator($input, $output);
         if ($migrator === null) {

--- a/src/xPDO/Console/Command/MigrationConsoleTrait.php
+++ b/src/xPDO/Console/Command/MigrationConsoleTrait.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use xPDO\Migrations\Exception\ConfigurationException;
+use xPDO\Migrations\MigrationConfig;
+use xPDO\Migrations\Migrator;
+use xPDO\xPDO;
+use xPDO\xPDOException;
+
+trait MigrationConsoleTrait
+{
+    protected function addMigrationOptions(): void
+    {
+        $this
+            ->addOption(
+                'config',
+                'C',
+                InputOption::VALUE_REQUIRED,
+                'A path to a config file'
+            )
+            ->addOption(
+                'platform',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'PDO platform (mysql, sqlite, pgsql, sqlsrv); defaults to xpdo_driver from config'
+            )
+            ->addOption(
+                'path',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override migrations_path'
+            )
+            ->addOption(
+                'namespace',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override migrations_namespace'
+            )
+            ->addOption(
+                'table',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override migrations_table'
+            )
+        ;
+    }
+
+    /**
+     * @return Migrator|null
+     */
+    protected function createMigrator(InputInterface $input, OutputInterface $output)
+    {
+        $properties = $this->loadConfig($output, $input->getOption('config'));
+        if ($properties === false) {
+            $output->writeln('fatal: no valid configuration file could be loaded');
+            return null;
+        }
+
+        $platform = $input->getOption('platform');
+        if ($platform === null || $platform === '') {
+            $platform = $properties['xpdo_driver'] ?? null;
+        }
+        $platform = is_string($platform) ? strtolower($platform) : '';
+        if ($platform === '' || !in_array($platform, self::$platforms, true)) {
+            $output->writeln('fatal: no valid platform specified (use --platform or xpdo_driver in config)');
+            return null;
+        }
+
+        $optionsKey = "{$platform}_array_options";
+        if (empty($properties[$optionsKey]) || !is_array($properties[$optionsKey])) {
+            $output->writeln("fatal: config is missing {$optionsKey}");
+            return null;
+        }
+
+        try {
+            $xpdo = xPDO::getInstance('migrations_' . $platform, $properties[$optionsKey]);
+        } catch (xPDOException $e) {
+            $output->writeln('fatal: ' . $e->getMessage());
+            return null;
+        }
+
+        $path = $input->getOption('path');
+        if ($path === null || $path === '') {
+            $path = $properties['migrations_path'] ?? null;
+        }
+        $namespace = $input->getOption('namespace');
+        if ($namespace === null || $namespace === '') {
+            $namespace = $properties['migrations_namespace'] ?? null;
+        }
+        $table = $input->getOption('table');
+        if ($table === null || $table === '') {
+            $table = $properties['migrations_table'] ?? null;
+        }
+
+        $configOptions = [
+            'migrations_path' => $path,
+            'migrations_namespace' => $namespace,
+        ];
+        if ($table !== null && $table !== '') {
+            $configOptions['migrations_table'] = $table;
+        }
+        if (!empty($properties['migrations_lock_name'])) {
+            $configOptions['migrations_lock_name'] = $properties['migrations_lock_name'];
+        }
+        if (!empty($properties['transaction_policy'])) {
+            $configOptions['transaction_policy'] = $properties['transaction_policy'];
+        }
+
+        try {
+            $config = MigrationConfig::fromArray($configOptions);
+        } catch (ConfigurationException $e) {
+            $output->writeln('fatal: ' . $e->getMessage());
+            return null;
+        }
+
+        return new Migrator($xpdo, $config);
+    }
+
+    /**
+     * @return int|null null when option omitted
+     */
+    protected function parseStepOption(InputInterface $input, OutputInterface $output): ?int
+    {
+        $raw = $input->getOption('step');
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        if (!is_numeric($raw) || (string)(int)$raw !== (string)$raw || (int)$raw < 1) {
+            $output->writeln('fatal: --step must be a positive integer');
+            return 0;
+        }
+        return (int)$raw;
+    }
+
+    protected function writeThrowable(OutputInterface $output, Throwable $e): void
+    {
+        $output->writeln('fatal: ' . $e->getMessage());
+        $previous = $e->getPrevious();
+        while ($previous !== null) {
+            $output->writeln('caused by: ' . $previous->getMessage());
+            $previous = $previous->getPrevious();
+        }
+        if ($output->isVerbose()) {
+            $output->writeln($e->getTraceAsString());
+        }
+    }
+
+    protected function writeResultLines(OutputInterface $output, iterable $items, string $emptyLabel = '(none)'): void
+    {
+        $items = is_array($items) ? $items : iterator_to_array($items);
+        if ($items === []) {
+            $output->writeln('  ' . $emptyLabel);
+            return;
+        }
+        foreach ($items as $item) {
+            $output->writeln('  - ' . $item);
+        }
+    }
+}

--- a/src/xPDO/Console/Command/ParseSchema.php
+++ b/src/xPDO/Console/Command/ParseSchema.php
@@ -63,7 +63,7 @@ final class ParseSchema extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $platform = strtolower($input->getArgument('platform'));
         if (!in_array($platform, self::$platforms)) {

--- a/src/xPDO/Console/Command/WriteSchema.php
+++ b/src/xPDO/Console/Command/WriteSchema.php
@@ -57,7 +57,7 @@ final class WriteSchema extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $platform = strtolower($input->getArgument('platform'));
         if (!in_array($platform, self::$platforms)) {

--- a/src/xPDO/Migrations/Exception/ConfigurationException.php
+++ b/src/xPDO/Migrations/Exception/ConfigurationException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations\Exception;
+
+/**
+ * Thrown for invalid migration configuration.
+ *
+ * Typical cases: missing/invalid migrations_path or namespace, remote path
+ * wrappers, bad migrations_table / lock name, unsupported transaction_policy.
+ *
+ * @package xPDO\Migrations\Exception
+ */
+class ConfigurationException extends MigrationException
+{
+}

--- a/src/xPDO/Migrations/Exception/InvalidMigrationException.php
+++ b/src/xPDO/Migrations/Exception/InvalidMigrationException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations\Exception;
+
+/**
+ * Thrown when a migration file or class cannot be used.
+ *
+ * Typical cases: bad name pattern, unreadable file, missing FQCN after load,
+ * class does not extend Migration, duplicate discovered name.
+ *
+ * @package xPDO\Migrations\Exception
+ */
+class InvalidMigrationException extends MigrationException
+{
+}

--- a/src/xPDO/Migrations/Exception/IrreversibleMigrationException.php
+++ b/src/xPDO/Migrations/Exception/IrreversibleMigrationException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations\Exception;
+
+/**
+ * Thrown from down() when the migration cannot be reversed.
+ *
+ * The ledger row stays applied. Fix the migration or restore the file, then
+ * re-run migrate-rollback.
+ *
+ * @package xPDO\Migrations\Exception
+ */
+class IrreversibleMigrationException extends MigrationException
+{
+}

--- a/src/xPDO/Migrations/Exception/MigrationException.php
+++ b/src/xPDO/Migrations/Exception/MigrationException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations\Exception;
+
+use xPDO\xPDOException;
+
+/**
+ * Base exception for the migrations subsystem.
+ *
+ * Catch this for any migrator/CLI failure. Prefer more specific subclasses when
+ * you need to branch on lock, config, invalid files, or irreversible down().
+ *
+ * @package xPDO\Migrations\Exception
+ */
+class MigrationException extends xPDOException
+{
+}

--- a/src/xPDO/Migrations/Exception/MigrationLockedException.php
+++ b/src/xPDO/Migrations/Exception/MigrationLockedException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations\Exception;
+
+/**
+ * Thrown when migrate/rollback cannot acquire the exclusive migration lock.
+ *
+ * MVP is fail-fast: another process holds the lock. Retry after that run ends.
+ *
+ * @package xPDO\Migrations\Exception
+ */
+class MigrationLockedException extends MigrationException
+{
+}

--- a/src/xPDO/Migrations/Migration.php
+++ b/src/xPDO/Migrations/Migration.php
@@ -11,6 +11,13 @@
 
 namespace xPDO\Migrations;
 
+/**
+ * Base class for user migration files. Extend and implement up()/down().
+ *
+ * Identity is the migration filename stem: YYYYMMDDHHMMSS_Description
+ * (see MigrationDiscoverer::NAME_PATTERN). Class name is M{that stem} in the
+ * configured namespace.
+ */
 abstract class Migration
 {
     abstract public function up(MigrationContext $context): void;

--- a/src/xPDO/Migrations/Migration.php
+++ b/src/xPDO/Migrations/Migration.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+abstract class Migration
+{
+    abstract public function up(MigrationContext $context): void;
+
+    abstract public function down(MigrationContext $context): void;
+
+    /**
+     * @return bool|null true/false override; null = use global config
+     */
+    public function isTransactional(): ?bool
+    {
+        return null;
+    }
+}

--- a/src/xPDO/Migrations/MigrationConfig.php
+++ b/src/xPDO/Migrations/MigrationConfig.php
@@ -13,6 +13,9 @@ namespace xPDO\Migrations;
 
 use xPDO\Migrations\Exception\ConfigurationException;
 
+/**
+ * Validated migration options (path, namespace, table, transaction policy, lock name).
+ */
 class MigrationConfig
 {
     public const POLICY_NON_TRANSACTIONAL = 'non_transactional';

--- a/src/xPDO/Migrations/MigrationConfig.php
+++ b/src/xPDO/Migrations/MigrationConfig.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use xPDO\Migrations\Exception\ConfigurationException;
+
+class MigrationConfig
+{
+    public const POLICY_NON_TRANSACTIONAL = 'non_transactional';
+    public const POLICY_TRANSACTIONAL = 'transactional';
+
+    /** @var string */
+    private $migrationsPath;
+
+    /** @var string */
+    private $migrationsNamespace;
+
+    /** @var string */
+    private $migrationsTable;
+
+    /** @var string|null */
+    private $migrationsLockName;
+
+    /** @var string */
+    private $transactionPolicy;
+
+    /**
+     * @param array $options
+     * @throws ConfigurationException
+     */
+    public function __construct(array $options)
+    {
+        if (empty($options['migrations_path']) || !is_string($options['migrations_path'])) {
+            throw new ConfigurationException('migrations_path is required');
+        }
+        if (empty($options['migrations_namespace']) || !is_string($options['migrations_namespace'])) {
+            throw new ConfigurationException('migrations_namespace is required');
+        }
+
+        $path = $options['migrations_path'];
+        $this->assertLocalPath($path);
+        $real = realpath($path);
+        if ($real === false) {
+            if (!is_dir($path) && !@mkdir($path, 0777, true) && !is_dir($path)) {
+                throw new ConfigurationException("migrations_path is not a usable directory: {$path}");
+            }
+            $real = realpath($path);
+            if ($real === false) {
+                throw new ConfigurationException("migrations_path could not be resolved: {$path}");
+            }
+        }
+        if (!is_dir($real)) {
+            throw new ConfigurationException("migrations_path is not a directory: {$path}");
+        }
+        $this->migrationsPath = $real;
+
+        $namespace = trim($options['migrations_namespace'], '\\');
+        if ($namespace === '' || !preg_match('/^[A-Za-z_][A-Za-z0-9_\\\\]*$/', $namespace)) {
+            throw new ConfigurationException('migrations_namespace is invalid');
+        }
+        $this->migrationsNamespace = $namespace;
+
+        $table = array_key_exists('migrations_table', $options) && $options['migrations_table'] !== null && $options['migrations_table'] !== ''
+            ? (string) $options['migrations_table']
+            : 'xpdo_migrations';
+        self::assertValidTableName($table);
+        $this->migrationsTable = $table;
+
+        $lockName = null;
+        if (!empty($options['migrations_lock_name'])) {
+            $lockName = (string) $options['migrations_lock_name'];
+            if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $lockName)) {
+                throw new ConfigurationException('migrations_lock_name is invalid');
+            }
+        }
+        $this->migrationsLockName = $lockName;
+
+        $policy = array_key_exists('transaction_policy', $options) && $options['transaction_policy'] !== null && $options['transaction_policy'] !== ''
+            ? (string) $options['transaction_policy']
+            : self::POLICY_NON_TRANSACTIONAL;
+        if (!in_array($policy, [self::POLICY_NON_TRANSACTIONAL, self::POLICY_TRANSACTIONAL], true)) {
+            throw new ConfigurationException('transaction_policy must be non_transactional or transactional');
+        }
+        $this->transactionPolicy = $policy;
+    }
+
+    /**
+     * @param array $options
+     * @return self
+     * @throws ConfigurationException
+     */
+    public static function fromArray(array $options)
+    {
+        return new self($options);
+    }
+
+    /**
+     * @param string $name
+     * @throws ConfigurationException
+     */
+    public static function assertValidTableName($name)
+    {
+        if (!is_string($name) || !preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            throw new ConfigurationException('Invalid SQL identifier for migrations table');
+        }
+    }
+
+    /**
+     * @param string $path
+     * @throws ConfigurationException
+     */
+    private function assertLocalPath($path)
+    {
+        if (preg_match('#^(?:[a-z][a-z0-9+.-]*)://#i', $path)) {
+            throw new ConfigurationException('migrations_path must be a local filesystem path');
+        }
+    }
+
+    public function getMigrationsPath()
+    {
+        return $this->migrationsPath;
+    }
+
+    public function getMigrationsNamespace()
+    {
+        return $this->migrationsNamespace;
+    }
+
+    public function getMigrationsTable()
+    {
+        return $this->migrationsTable;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMigrationsLockName()
+    {
+        return $this->migrationsLockName;
+    }
+
+    public function getTransactionPolicy()
+    {
+        return $this->transactionPolicy;
+    }
+
+    public function isTransactionalDefault()
+    {
+        return $this->transactionPolicy === self::POLICY_TRANSACTIONAL;
+    }
+}

--- a/src/xPDO/Migrations/MigrationContext.php
+++ b/src/xPDO/Migrations/MigrationContext.php
@@ -14,6 +14,10 @@ namespace xPDO\Migrations;
 use Psr\Log\LoggerInterface;
 use xPDO\xPDO;
 
+/**
+ * Runtime handle passed into Migration::up/down. Prefer getXpdo() over capturing
+ * connections yourself for the duration of the method.
+ */
 final class MigrationContext
 {
     /** @var xPDO */

--- a/src/xPDO/Migrations/MigrationContext.php
+++ b/src/xPDO/Migrations/MigrationContext.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use Psr\Log\LoggerInterface;
+use xPDO\xPDO;
+
+final class MigrationContext
+{
+    /** @var xPDO */
+    private $xpdo;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var string */
+    private $migrationName;
+
+    /** @var MigrationConfig */
+    private $config;
+
+    public function __construct(xPDO $xpdo, LoggerInterface $logger, string $migrationName, MigrationConfig $config)
+    {
+        $this->xpdo = $xpdo;
+        $this->logger = $logger;
+        $this->migrationName = $migrationName;
+        $this->config = $config;
+    }
+
+    public function getXpdo(): xPDO
+    {
+        return $this->xpdo;
+    }
+
+    public function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    public function getMigrationName(): string
+    {
+        return $this->migrationName;
+    }
+
+    public function getConfig(): MigrationConfig
+    {
+        return $this->config;
+    }
+}

--- a/src/xPDO/Migrations/MigrationDiscoverer.php
+++ b/src/xPDO/Migrations/MigrationDiscoverer.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use DirectoryIterator;
+use xPDO\Migrations\Exception\InvalidMigrationException;
+
+/**
+ * @internal Not a stable extension API. Prefer Migrator / Migration / MigrationContext / MigrationConfig.
+ */
+class MigrationDiscoverer
+{
+    public const NAME_PATTERN = '/^[0-9]{14}_[A-Za-z][A-Za-z0-9]*$/';
+
+    /** @var MigrationConfig */
+    private $config;
+
+    public function __construct(MigrationConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return array<int, array{name:string,class:string,file:string}>
+     */
+    public function discover(): array
+    {
+        $path = $this->config->getMigrationsPath();
+        $found = [];
+        $seen = [];
+
+        foreach (new DirectoryIterator($path) as $file) {
+            if (!$file->isFile() || strtolower($file->getExtension()) !== 'php') {
+                continue;
+            }
+            $basename = $file->getBasename('.php');
+            if (!preg_match(self::NAME_PATTERN, $basename)) {
+                continue;
+            }
+            if (isset($seen[$basename])) {
+                throw new InvalidMigrationException("Duplicate migration name: {$basename}");
+            }
+            $seen[$basename] = true;
+            $class = $this->classNameFor($basename);
+            $found[] = [
+                'name' => $basename,
+                'class' => $class,
+                'file' => $file->getPathname(),
+            ];
+        }
+
+        usort($found, static function ($a, $b) {
+            return strcmp($a['name'], $b['name']);
+        });
+
+        return $found;
+    }
+
+    public function load(string $name): Migration
+    {
+        if (!preg_match(self::NAME_PATTERN, $name)) {
+            throw new InvalidMigrationException("Invalid migration name: {$name}");
+        }
+        $file = $this->config->getMigrationsPath() . DIRECTORY_SEPARATOR . $name . '.php';
+        if (!is_readable($file)) {
+            throw new InvalidMigrationException("Migration file not readable: {$file}");
+        }
+
+        require_once $file;
+        $class = $this->classNameFor($name);
+        if (!class_exists($class)) {
+            throw new InvalidMigrationException("Migration class not found: {$class}");
+        }
+        $instance = new $class();
+        if (!$instance instanceof Migration) {
+            throw new InvalidMigrationException("Migration class must extend Migration: {$class}");
+        }
+        return $instance;
+    }
+
+    public function classNameFor(string $migrationName): string
+    {
+        return $this->config->getMigrationsNamespace() . '\\M' . $migrationName;
+    }
+}

--- a/src/xPDO/Migrations/MigrationExecutor.php
+++ b/src/xPDO/Migrations/MigrationExecutor.php
@@ -36,12 +36,21 @@ class MigrationExecutor
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct(xPDO $xpdo, MigrationConfig $config, MigrationRepository $repository, LoggerInterface $logger)
-    {
+    /** @var callable|null */
+    private $ensurePinnedConnection;
+
+    public function __construct(
+        xPDO $xpdo,
+        MigrationConfig $config,
+        MigrationRepository $repository,
+        LoggerInterface $logger,
+        ?callable $ensurePinnedConnection = null
+    ) {
         $this->xpdo = $xpdo;
         $this->config = $config;
         $this->repository = $repository;
         $this->logger = $logger;
+        $this->ensurePinnedConnection = $ensurePinnedConnection;
     }
 
     public function applyUp(Migration $migration, string $name, int $batch): void
@@ -51,6 +60,8 @@ class MigrationExecutor
 
         $this->runInPolicy($transactional, $name, 'up', function () use ($migration, $context, $name, $batch) {
             $migration->up($context);
+            // Ledger write must use the same pinned connection as the migration run.
+            $this->restorePinnedConnection();
             $this->repository->insert($name, $batch, new DateTimeImmutable('now', new DateTimeZone('UTC')));
         });
     }
@@ -62,8 +73,16 @@ class MigrationExecutor
 
         $this->runInPolicy($transactional, $name, 'down', function () use ($migration, $context, $name) {
             $migration->down($context);
+            $this->restorePinnedConnection();
             $this->repository->delete($name);
         });
+    }
+
+    private function restorePinnedConnection(): void
+    {
+        if ($this->ensurePinnedConnection !== null) {
+            ($this->ensurePinnedConnection)();
+        }
     }
 
     private function resolveTransactional(Migration $migration): bool

--- a/src/xPDO/Migrations/MigrationExecutor.php
+++ b/src/xPDO/Migrations/MigrationExecutor.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use xPDO\Migrations\Exception\IrreversibleMigrationException;
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\xPDO;
+
+/**
+ * @internal Not a stable extension API. Prefer Migrator / Migration / MigrationContext / MigrationConfig.
+ */
+class MigrationExecutor
+{
+    /** @var xPDO */
+    private $xpdo;
+
+    /** @var MigrationConfig */
+    private $config;
+
+    /** @var MigrationRepository */
+    private $repository;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(xPDO $xpdo, MigrationConfig $config, MigrationRepository $repository, LoggerInterface $logger)
+    {
+        $this->xpdo = $xpdo;
+        $this->config = $config;
+        $this->repository = $repository;
+        $this->logger = $logger;
+    }
+
+    public function applyUp(Migration $migration, string $name, int $batch): void
+    {
+        $context = new MigrationContext($this->xpdo, $this->logger, $name, $this->config);
+        $transactional = $this->resolveTransactional($migration);
+
+        $this->runInPolicy($transactional, $name, 'up', function () use ($migration, $context, $name, $batch) {
+            $migration->up($context);
+            $this->repository->insert($name, $batch, new DateTimeImmutable('now', new DateTimeZone('UTC')));
+        });
+    }
+
+    public function applyDown(Migration $migration, string $name): void
+    {
+        $context = new MigrationContext($this->xpdo, $this->logger, $name, $this->config);
+        $transactional = $this->resolveTransactional($migration);
+
+        $this->runInPolicy($transactional, $name, 'down', function () use ($migration, $context, $name) {
+            $migration->down($context);
+            $this->repository->delete($name);
+        });
+    }
+
+    private function resolveTransactional(Migration $migration): bool
+    {
+        $override = $migration->isTransactional();
+        if ($override !== null) {
+            return $override;
+        }
+        return $this->config->isTransactionalDefault();
+    }
+
+    private function runInPolicy(bool $transactional, string $name, string $direction, callable $fn): void
+    {
+        if (!$this->xpdo->connect(null, [xPDO::OPT_CONN_MUTABLE => true])) {
+            throw new MigrationException('Could not obtain a mutable database connection');
+        }
+
+        $alreadyInTxn = $this->xpdo->pdo && $this->xpdo->pdo->inTransaction();
+        $opened = false;
+
+        if ($transactional && !$alreadyInTxn) {
+            if ($this->xpdo->beginTransaction() === false) {
+                throw new MigrationException(
+                    "Could not begin transaction before migration {$name} ({$direction})"
+                );
+            }
+            $opened = true;
+        }
+
+        try {
+            $fn();
+            if ($opened) {
+                if ($this->xpdo->commit() === false) {
+                    throw new MigrationException(
+                        "Could not commit transaction after migration {$name} ({$direction})"
+                    );
+                }
+            }
+        } catch (IrreversibleMigrationException $e) {
+            if ($opened && $this->xpdo->pdo && $this->xpdo->pdo->inTransaction()) {
+                $this->xpdo->rollBack();
+            }
+            throw $e;
+        } catch (MigrationException $e) {
+            if ($opened && $this->xpdo->pdo && $this->xpdo->pdo->inTransaction()) {
+                $this->xpdo->rollBack();
+            }
+            throw $e;
+        } catch (Throwable $e) {
+            if ($opened && $this->xpdo->pdo && $this->xpdo->pdo->inTransaction()) {
+                $this->xpdo->rollBack();
+            }
+            throw new MigrationException(
+                "Migration {$name} failed during {$direction}: " . $e->getMessage(),
+                (int) $e->getCode(),
+                $e
+            );
+        }
+    }
+}

--- a/src/xPDO/Migrations/MigrationGenerator.php
+++ b/src/xPDO/Migrations/MigrationGenerator.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use xPDO\Migrations\Exception\ConfigurationException;
+
+/**
+ * @internal Not a stable extension API. Prefer Migrator / Migration / MigrationContext / MigrationConfig.
+ */
+class MigrationGenerator
+{
+    /** @var MigrationConfig */
+    private $config;
+
+    public function __construct(MigrationConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Create a new migration stub. Returns the migration name.
+     *
+     * @throws ConfigurationException
+     */
+    public function create(string $description): string
+    {
+        $description = $this->normalizeDescription($description);
+        $name = $this->nextUniqueName($description);
+        $class = 'M' . $name;
+        $namespace = $this->config->getMigrationsNamespace();
+        $path = $this->config->getMigrationsPath() . DIRECTORY_SEPARATOR . $name . '.php';
+        $contents = $this->renderStub($namespace, $class);
+
+        $handle = @fopen($path, 'x');
+        if ($handle === false) {
+            throw new ConfigurationException("Migration file already exists or could not be created: {$path}");
+        }
+        try {
+            if (fwrite($handle, $contents) === false) {
+                throw new ConfigurationException("Could not write migration file: {$path}");
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return $name;
+    }
+
+    private function normalizeDescription(string $description): string
+    {
+        $description = preg_replace('/[^A-Za-z0-9]+/', '', $description) ?? '';
+        if ($description === '' || !preg_match('/^[A-Za-z][A-Za-z0-9]*$/', $description)) {
+            throw new ConfigurationException(
+                'Migration description must start with a letter and contain only letters and digits'
+            );
+        }
+        return $description;
+    }
+
+    private function nextUniqueName(string $description): string
+    {
+        $dir = $this->config->getMigrationsPath();
+        $dt = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        for ($i = 0; $i < 1000; $i++) {
+            $ts = $dt->modify('+' . $i . ' seconds')->format('YmdHis');
+            $name = $ts . '_' . $description;
+            if (strlen($name) > 191) {
+                throw new ConfigurationException('Migration name exceeds 191 characters');
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $name . '.php';
+            if (!file_exists($path)) {
+                return $name;
+            }
+        }
+        throw new ConfigurationException('Could not allocate a unique migration timestamp');
+    }
+
+    private function renderStub(string $namespace, string $class): string
+    {
+        return <<<PHP
+<?php
+/**
+ * Auto-generated xPDO migration.
+ */
+
+namespace {$namespace};
+
+use xPDO\Migrations\Exception\IrreversibleMigrationException;
+use xPDO\Migrations\Migration;
+use xPDO\Migrations\MigrationContext;
+
+class {$class} extends Migration
+{
+    public function up(MigrationContext \$context): void
+    {
+        // Put schema/data changes here (\$context->getXpdo()).
+        // Global default is non_transactional: MySQL DDL is not atomic.
+    }
+
+    public function down(MigrationContext \$context): void
+    {
+        // Reverse up(), or leave this throw for irreversible migrations.
+        throw new IrreversibleMigrationException('down() is not implemented for {$class}');
+    }
+}
+
+PHP;
+    }
+}

--- a/src/xPDO/Migrations/MigrationLock.php
+++ b/src/xPDO/Migrations/MigrationLock.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use PDO;
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\Migrations\Exception\MigrationLockedException;
+use xPDO\xPDO;
+
+/**
+ * @internal Not a stable extension API. Prefer Migrator / Migration / MigrationContext / MigrationConfig.
+ */
+class MigrationLock
+{
+    /** @var xPDO */
+    private $xpdo;
+
+    /** @var MigrationConfig */
+    private $config;
+
+    /** @var bool */
+    private $held = false;
+
+    /** @var string|null */
+    private $mysqlKey;
+
+    /** @var array{0:int,1:int}|null */
+    private $pgsqlKeys;
+
+    /** @var resource|null */
+    private $sqliteLockHandle;
+
+    public function __construct(xPDO $xpdo, MigrationConfig $config)
+    {
+        $this->xpdo = $xpdo;
+        $this->config = $config;
+    }
+
+    public function acquire(): void
+    {
+        if ($this->held) {
+            return;
+        }
+        if (!$this->xpdo->connect(null, [xPDO::OPT_CONN_MUTABLE => true])) {
+            throw new MigrationException('Could not obtain a mutable database connection for locking');
+        }
+
+        $dbtype = $this->xpdo->getOption('dbtype');
+        switch ($dbtype) {
+            case 'mysql':
+                $this->acquireMysql();
+                break;
+            case 'pgsql':
+                $this->acquirePgsql();
+                break;
+            case 'sqlite':
+                $this->acquireSqlite();
+                break;
+            default:
+                throw new MigrationException("Migration locking is not supported for dbtype {$dbtype}");
+        }
+        $this->held = true;
+    }
+
+    public function release(bool $successful = true): void
+    {
+        if (!$this->held) {
+            return;
+        }
+        $dbtype = $this->xpdo->getOption('dbtype');
+        try {
+            switch ($dbtype) {
+                case 'mysql':
+                    if ($this->mysqlKey !== null && $this->xpdo->pdo) {
+                        $stmt = $this->xpdo->prepare('SELECT RELEASE_LOCK(?)');
+                        if ($stmt) {
+                            $stmt->execute([$this->mysqlKey]);
+                        }
+                    }
+                    break;
+                case 'pgsql':
+                    if ($this->pgsqlKeys !== null && $this->xpdo->pdo) {
+                        $stmt = $this->xpdo->prepare('SELECT pg_advisory_unlock(?, ?)');
+                        if ($stmt) {
+                            $stmt->execute([$this->pgsqlKeys[0], $this->pgsqlKeys[1]]);
+                        }
+                    }
+                    break;
+                case 'sqlite':
+                    if ($this->sqliteLockHandle) {
+                        flock($this->sqliteLockHandle, LOCK_UN);
+                        fclose($this->sqliteLockHandle);
+                        $this->sqliteLockHandle = null;
+                    }
+                    break;
+            }
+        } finally {
+            $this->held = false;
+            $this->mysqlKey = null;
+            $this->pgsqlKeys = null;
+            $this->sqliteLockHandle = null;
+        }
+    }
+
+    private function acquireMysql(): void
+    {
+        $key = substr(hash('sha256', $this->buildKey()), 0, 64);
+        $stmt = $this->xpdo->prepare('SELECT GET_LOCK(?, 0)');
+        if ($stmt === false || $stmt->execute([$key]) === false) {
+            throw new MigrationException('GET_LOCK failed');
+        }
+        $row = $stmt->fetch(PDO::FETCH_NUM);
+        if (!$row || (int) $row[0] !== 1) {
+            throw new MigrationLockedException('Could not acquire migration lock');
+        }
+        $this->mysqlKey = $key;
+    }
+
+    private function acquirePgsql(): void
+    {
+        $hash = hash('sha256', $this->buildKey(), true);
+        $k1 = unpack('N', substr($hash, 0, 4))[1] & 0x7fffffff;
+        $k2 = unpack('N', substr($hash, 4, 4))[1] & 0x7fffffff;
+        $stmt = $this->xpdo->prepare('SELECT pg_try_advisory_lock(?, ?)');
+        if ($stmt === false || $stmt->execute([$k1, $k2]) === false) {
+            throw new MigrationException('pg_try_advisory_lock failed');
+        }
+        $row = $stmt->fetch(PDO::FETCH_NUM);
+        if (!$row || !($row[0] === true || $row[0] === 't' || (int) $row[0] === 1)) {
+            throw new MigrationLockedException('Could not acquire migration lock');
+        }
+        $this->pgsqlKeys = [$k1, $k2];
+    }
+
+    private function acquireSqlite(): void
+    {
+        $dir = $this->config->getMigrationsPath();
+        $file = $dir . DIRECTORY_SEPARATOR . '.xpdo_migration.lock';
+        $handle = fopen($file, 'c+');
+        if ($handle === false) {
+            throw new MigrationException('Could not open sqlite migration lock file');
+        }
+        if (!flock($handle, LOCK_EX | LOCK_NB)) {
+            fclose($handle);
+            throw new MigrationLockedException('Could not acquire migration lock');
+        }
+        $this->sqliteLockHandle = $handle;
+    }
+
+    private function buildKey(): string
+    {
+        $parts = [
+            'xpdo_migrations',
+            $this->config->getMigrationsTable(),
+            (string) $this->xpdo->getOption('dbname', null, ''),
+            (string) $this->xpdo->getOption('dsn', null, ''),
+        ];
+        if ($this->config->getMigrationsLockName()) {
+            $parts[] = $this->config->getMigrationsLockName();
+        }
+        return implode('|', $parts);
+    }
+}

--- a/src/xPDO/Migrations/MigrationLock.php
+++ b/src/xPDO/Migrations/MigrationLock.php
@@ -71,7 +71,7 @@ class MigrationLock
         $this->held = true;
     }
 
-    public function release(bool $successful = true): void
+    public function release(): void
     {
         if (!$this->held) {
             return;

--- a/src/xPDO/Migrations/MigrationPsrLogger.php
+++ b/src/xPDO/Migrations/MigrationPsrLogger.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use xPDO\xPDO;
+
+/**
+ * PSR-3 adapter that forwards to xPDO::log without using FATAL.
+ */
+/**
+ * @internal Not a stable extension API. Prefer Migrator / Migration / MigrationContext / MigrationConfig.
+ */
+final class MigrationPsrLogger extends AbstractLogger
+{
+    /** @var xPDO */
+    private $xpdo;
+
+    public function __construct(xPDO $xpdo)
+    {
+        $this->xpdo = $xpdo;
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $map = [
+            LogLevel::DEBUG => xPDO::LOG_LEVEL_DEBUG,
+            LogLevel::INFO => xPDO::LOG_LEVEL_INFO,
+            LogLevel::NOTICE => xPDO::LOG_LEVEL_INFO,
+            LogLevel::WARNING => xPDO::LOG_LEVEL_WARN,
+            LogLevel::ERROR => xPDO::LOG_LEVEL_ERROR,
+            LogLevel::CRITICAL => xPDO::LOG_LEVEL_ERROR,
+            LogLevel::ALERT => xPDO::LOG_LEVEL_ERROR,
+            LogLevel::EMERGENCY => xPDO::LOG_LEVEL_ERROR,
+        ];
+        $xpdoLevel = $map[$level] ?? xPDO::LOG_LEVEL_INFO;
+        $this->xpdo->log($xpdoLevel, (string) $message);
+    }
+}

--- a/src/xPDO/Migrations/MigrationRepository.php
+++ b/src/xPDO/Migrations/MigrationRepository.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use PDO;
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\xPDO;
+
+/**
+ * @internal Not a stable extension API. Prefer Migrator / Migration / MigrationContext / MigrationConfig.
+ */
+class MigrationRepository
+{
+    /** @var xPDO */
+    private $xpdo;
+
+    /** @var MigrationConfig */
+    private $config;
+
+    public function __construct(xPDO $xpdo, MigrationConfig $config)
+    {
+        $this->xpdo = $xpdo;
+        $this->config = $config;
+    }
+
+    public function exists(): bool
+    {
+        try {
+            $this->pinConnection();
+        } catch (\Throwable $e) {
+            return false;
+        }
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        $dbtype = $this->xpdo->getOption('dbtype');
+
+        try {
+            switch ($dbtype) {
+                case 'sqlite':
+                    $sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=" . $this->xpdo->quote($this->config->getMigrationsTable());
+                    $stmt = $this->xpdo->query($sql);
+                    break;
+                case 'pgsql':
+                    $sql = "SELECT 1 FROM information_schema.tables WHERE table_name = " . $this->xpdo->quote($this->config->getMigrationsTable()) . " AND table_schema = current_schema()";
+                    $stmt = $this->xpdo->query($sql);
+                    break;
+                case 'mysql':
+                default:
+                    $sql = "SELECT 1 FROM {$table} LIMIT 1";
+                    $stmt = $this->xpdo->query($sql);
+                    break;
+            }
+            if ($stmt === false) {
+                return false;
+            }
+            if ($dbtype === 'sqlite' || $dbtype === 'pgsql') {
+                $row = $stmt->fetch(PDO::FETCH_NUM);
+                return !empty($row);
+            }
+            return true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @throws MigrationException
+     */
+    public function ensure(): void
+    {
+        if ($this->exists()) {
+            return;
+        }
+        $this->pinConnection();
+        $dbtype = $this->xpdo->getOption('dbtype');
+        $sql = $this->createTableSql($dbtype);
+        if ($this->runWrite($sql) === false) {
+            throw new MigrationException('Could not create migrations repository table: ' . json_encode($this->xpdo->errorInfo()));
+        }
+        if ($dbtype === 'sqlite' || $dbtype === 'pgsql') {
+            $idx = 'CREATE INDEX IF NOT EXISTS ' . $this->quoteIdent($this->config->getMigrationsTable() . '_batch')
+                . ' ON ' . $this->quoteIdent($this->config->getMigrationsTable()) . ' (batch)';
+            $this->runWrite($idx);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function fetchAppliedVersions(): array
+    {
+        $this->pinConnection();
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        $stmt = $this->xpdo->query("SELECT version FROM {$table} ORDER BY version ASC");
+        if ($stmt === false) {
+            throw new MigrationException('Could not read applied migrations');
+        }
+        $versions = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $versions[] = $row['version'];
+        }
+        return $versions;
+    }
+
+    /**
+     * @return array<int, array{version:string,batch:int,applied_at:string}>
+     */
+    public function fetchByBatch(int $batch): array
+    {
+        $this->pinConnection();
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        $stmt = $this->xpdo->prepare("SELECT version, batch, applied_at FROM {$table} WHERE batch = ? ORDER BY version DESC");
+        if ($stmt === false || $stmt->execute([$batch]) === false) {
+            throw new MigrationException('Could not read migrations for batch');
+        }
+        $rows = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $rows[] = [
+                'version' => $row['version'],
+                'batch' => (int) $row['batch'],
+                'applied_at' => $row['applied_at'],
+            ];
+        }
+        return $rows;
+    }
+
+    public function maxBatch(): int
+    {
+        $this->pinConnection();
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        $stmt = $this->xpdo->query("SELECT MAX(batch) AS m FROM {$table}");
+        if ($stmt === false) {
+            return 0;
+        }
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row || $row['m'] === null) {
+            return 0;
+        }
+        return (int) $row['m'];
+    }
+
+    public function nextBatch(): int
+    {
+        return $this->maxBatch() + 1;
+    }
+
+    public function insert(string $version, int $batch, DateTimeInterface $at): void
+    {
+        $this->pinConnection();
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        $utc = DateTimeImmutable::createFromInterface($at)->setTimezone(new DateTimeZone('UTC'));
+        $appliedAt = $utc->format('Y-m-d H:i:s');
+        $stmt = $this->xpdo->prepare("INSERT INTO {$table} (version, batch, applied_at) VALUES (?, ?, ?)");
+        if ($stmt === false || $stmt->execute([$version, $batch, $appliedAt]) === false) {
+            throw new MigrationException('Could not record migration ' . $version);
+        }
+    }
+
+    public function delete(string $version): void
+    {
+        $this->pinConnection();
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        $stmt = $this->xpdo->prepare("DELETE FROM {$table} WHERE version = ?");
+        if ($stmt === false || $stmt->execute([$version]) === false) {
+            throw new MigrationException('Could not remove migration record ' . $version);
+        }
+    }
+
+    /**
+     * @return int|false
+     */
+    private function runWrite(string $sql)
+    {
+        return $this->xpdo->{'exec'}($sql);
+    }
+
+    private function createTableSql(string $dbtype): string
+    {
+        $table = $this->quoteIdent($this->config->getMigrationsTable());
+        switch ($dbtype) {
+            case 'pgsql':
+                return "CREATE TABLE {$table} ("
+                    . "id SERIAL PRIMARY KEY, "
+                    . "version VARCHAR(191) NOT NULL UNIQUE, "
+                    . "batch INTEGER NOT NULL, "
+                    . "applied_at TIMESTAMP NOT NULL"
+                    . ")";
+            case 'sqlite':
+                return "CREATE TABLE {$table} ("
+                    . "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    . "version VARCHAR(191) NOT NULL UNIQUE, "
+                    . "batch INTEGER NOT NULL, "
+                    . "applied_at TEXT NOT NULL"
+                    . ")";
+            case 'mysql':
+            default:
+                $batchIndex = $this->quoteIdent($this->config->getMigrationsTable() . '_batch');
+                return "CREATE TABLE {$table} ("
+                    . "id INT NOT NULL AUTO_INCREMENT, "
+                    . "version VARCHAR(191) NOT NULL, "
+                    . "batch INT NOT NULL, "
+                    . "applied_at DATETIME NOT NULL, "
+                    . "PRIMARY KEY (id), "
+                    . "UNIQUE KEY version (version), "
+                    . "KEY {$batchIndex} (batch)"
+                    . ") DEFAULT CHARSET=utf8mb4";
+        }
+    }
+
+    private function quoteIdent(string $ident): string
+    {
+        MigrationConfig::assertValidTableName($ident);
+        return $this->xpdo->escape($ident);
+    }
+
+    private function pinConnection(): void
+    {
+        if (!$this->xpdo->connect(null, [xPDO::OPT_CONN_MUTABLE => true])) {
+            throw new MigrationException('Could not obtain a mutable database connection');
+        }
+    }
+}

--- a/src/xPDO/Migrations/Migrator.php
+++ b/src/xPDO/Migrations/Migrator.php
@@ -12,11 +12,16 @@
 namespace xPDO\Migrations;
 
 use Psr\Log\LoggerInterface;
-use Throwable;
 use xPDO\Migrations\Exception\MigrationException;
 use xPDO\xPDO;
 use xPDO\xPDOConnection;
 
+/**
+ * Public entry point for applying, inspecting, creating, and rolling back migrations.
+ *
+ * Stable surface for consumers: this class, Migration, MigrationContext, MigrationConfig,
+ * and MigratorResult DTOs returned by these methods.
+ */
 class Migrator
 {
     /** @var xPDO */
@@ -59,11 +64,22 @@ class Migrator
         $this->logger = $logger ?: $this->resolveLogger($xpdo);
         $this->repository = new MigrationRepository($xpdo, $config);
         $this->discoverer = new MigrationDiscoverer($config);
-        $this->executor = new MigrationExecutor($xpdo, $config, $this->repository, $this->logger);
+        $this->executor = new MigrationExecutor(
+            $xpdo,
+            $config,
+            $this->repository,
+            $this->logger,
+            function (): void {
+                $this->restorePinnedConnection();
+            }
+        );
         $this->lock = new MigrationLock($xpdo, $config);
         $this->generator = new MigrationGenerator($config);
     }
 
+    /**
+     * Inspect applied / pending / orphaned versions. Does not create the ledger table.
+     */
     public function status(): MigratorResult
     {
         if (!$this->repository->exists()) {
@@ -89,13 +105,16 @@ class Migrator
         return $result;
     }
 
+    /**
+     * Apply pending migrations in ascending name order. Optional $step caps how many.
+     * Failed up() is not recorded; later pending in the same run are not attempted.
+     */
     public function migrate(?int $step = null): MigratorResult
     {
-        $success = false;
         $this->beginPinnedRun();
         $this->lock->acquire();
         try {
-            return $this->withAutoCreateDisabled(function () use ($step, &$success) {
+            return $this->withAutoCreateDisabled(function () use ($step) {
                 $this->repository->ensure();
                 $discovered = $this->discoverer->discover();
                 $applied = array_fill_keys($this->repository->fetchAppliedVersions(), true);
@@ -111,7 +130,6 @@ class Migrator
                 if ($pending === []) {
                     $result->applied = [];
                     $result->pending = [];
-                    $success = true;
                     return $result;
                 }
 
@@ -136,18 +154,17 @@ class Migrator
                 $result->applied = $appliedNow;
                 $status = $this->status();
                 $result->pending = $status->pending;
-                $success = true;
                 return $result;
             });
-        } catch (Throwable $e) {
-            $success = false;
-            throw $e;
         } finally {
-            $this->lock->release($success);
+            $this->lock->release();
             $this->endPinnedRun();
         }
     }
 
+    /**
+     * Write a new migration stub on disk. Does not require a live database connection.
+     */
     public function create(string $description): MigratorResult
     {
         $name = $this->generator->create($description);
@@ -158,13 +175,16 @@ class Migrator
         return $result;
     }
 
+    /**
+     * Reverse rows with batch = MAX(batch), highest version first. Optional $step caps count.
+     * Failed down() leaves the ledger row in place.
+     */
     public function rollback(?int $step = null): MigratorResult
     {
-        $success = false;
         $this->beginPinnedRun();
         $this->lock->acquire();
         try {
-            return $this->withAutoCreateDisabled(function () use ($step, &$success) {
+            return $this->withAutoCreateDisabled(function () use ($step) {
                 $this->repository->ensure();
 
                 $result = new MigratorResult(MigratorResult::REPOSITORY_OK);
@@ -173,7 +193,6 @@ class Migrator
                     $status = $this->status();
                     $result->applied = $status->applied;
                     $result->pending = $status->pending;
-                    $success = true;
                     return $result;
                 }
 
@@ -199,14 +218,10 @@ class Migrator
                 $status = $this->status();
                 $result->applied = $status->applied;
                 $result->pending = $status->pending;
-                $success = true;
                 return $result;
             });
-        } catch (Throwable $e) {
-            $success = false;
-            throw $e;
         } finally {
-            $this->lock->release($success);
+            $this->lock->release();
             $this->endPinnedRun();
         }
     }

--- a/src/xPDO/Migrations/Migrator.php
+++ b/src/xPDO/Migrations/Migrator.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+use Psr\Log\LoggerInterface;
+use Throwable;
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\xPDO;
+use xPDO\xPDOConnection;
+
+class Migrator
+{
+    /** @var xPDO */
+    private $xpdo;
+
+    /** @var MigrationConfig */
+    private $config;
+
+    /** @var MigrationRepository */
+    private $repository;
+
+    /** @var MigrationDiscoverer */
+    private $discoverer;
+
+    /** @var MigrationExecutor */
+    private $executor;
+
+    /** @var MigrationLock */
+    private $lock;
+
+    /** @var MigrationGenerator */
+    private $generator;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var mixed */
+    private $previousAutoCreate;
+
+    /** @var xPDOConnection|null */
+    private $pinnedConnection = null;
+
+    /** @var \PDO|null */
+    private $pinnedPdo = null;
+
+    public function __construct(xPDO $xpdo, MigrationConfig $config, ?LoggerInterface $logger = null)
+    {
+        $this->xpdo = $xpdo;
+        $this->config = $config;
+        $this->logger = $logger ?: $this->resolveLogger($xpdo);
+        $this->repository = new MigrationRepository($xpdo, $config);
+        $this->discoverer = new MigrationDiscoverer($config);
+        $this->executor = new MigrationExecutor($xpdo, $config, $this->repository, $this->logger);
+        $this->lock = new MigrationLock($xpdo, $config);
+        $this->generator = new MigrationGenerator($config);
+    }
+
+    public function status(): MigratorResult
+    {
+        if (!$this->repository->exists()) {
+            return new MigratorResult(MigratorResult::REPOSITORY_MISSING);
+        }
+
+        $result = new MigratorResult(MigratorResult::REPOSITORY_OK);
+        $result->applied = $this->repository->fetchAppliedVersions();
+        $discovered = $this->discoverer->discover();
+        $appliedMap = array_fill_keys($result->applied, true);
+        $discoveredMap = [];
+        foreach ($discovered as $item) {
+            $discoveredMap[$item['name']] = true;
+            if (!isset($appliedMap[$item['name']])) {
+                $result->pending[] = $item['name'];
+            }
+        }
+        foreach ($result->applied as $version) {
+            if (!isset($discoveredMap[$version])) {
+                $result->orphaned[] = $version;
+            }
+        }
+        return $result;
+    }
+
+    public function migrate(?int $step = null): MigratorResult
+    {
+        $success = false;
+        $this->beginPinnedRun();
+        $this->lock->acquire();
+        try {
+            return $this->withAutoCreateDisabled(function () use ($step, &$success) {
+                $this->repository->ensure();
+                $discovered = $this->discoverer->discover();
+                $applied = array_fill_keys($this->repository->fetchAppliedVersions(), true);
+
+                $pending = [];
+                foreach ($discovered as $item) {
+                    if (!isset($applied[$item['name']])) {
+                        $pending[] = $item;
+                    }
+                }
+
+                $result = new MigratorResult(MigratorResult::REPOSITORY_OK);
+                if ($pending === []) {
+                    $result->applied = [];
+                    $result->pending = [];
+                    $success = true;
+                    return $result;
+                }
+
+                if ($step !== null) {
+                    if ($step < 1) {
+                        throw new MigrationException('step must be a positive integer');
+                    }
+                    $pending = array_slice($pending, 0, $step);
+                }
+
+                $batch = $this->repository->nextBatch();
+                $result->batch = $batch;
+                $appliedNow = [];
+
+                foreach ($pending as $item) {
+                    $this->restorePinnedConnection();
+                    $migration = $this->discoverer->load($item['name']);
+                    $this->executor->applyUp($migration, $item['name'], $batch);
+                    $appliedNow[] = $item['name'];
+                }
+
+                $result->applied = $appliedNow;
+                $status = $this->status();
+                $result->pending = $status->pending;
+                $success = true;
+                return $result;
+            });
+        } catch (Throwable $e) {
+            $success = false;
+            throw $e;
+        } finally {
+            $this->lock->release($success);
+            $this->endPinnedRun();
+        }
+    }
+
+    public function create(string $description): MigratorResult
+    {
+        $name = $this->generator->create($description);
+        // File generation must not require a live database connection.
+        $result = new MigratorResult(MigratorResult::REPOSITORY_MISSING);
+        $result->created = $name;
+        $result->messages[] = 'Created ' . $this->config->getMigrationsPath() . DIRECTORY_SEPARATOR . $name . '.php';
+        return $result;
+    }
+
+    public function rollback(?int $step = null): MigratorResult
+    {
+        $success = false;
+        $this->beginPinnedRun();
+        $this->lock->acquire();
+        try {
+            return $this->withAutoCreateDisabled(function () use ($step, &$success) {
+                $this->repository->ensure();
+
+                $result = new MigratorResult(MigratorResult::REPOSITORY_OK);
+                $maxBatch = $this->repository->maxBatch();
+                if ($maxBatch < 1) {
+                    $status = $this->status();
+                    $result->applied = $status->applied;
+                    $result->pending = $status->pending;
+                    $success = true;
+                    return $result;
+                }
+
+                $rows = $this->repository->fetchByBatch($maxBatch);
+                if ($step !== null) {
+                    if ($step < 1) {
+                        throw new MigrationException('step must be a positive integer');
+                    }
+                    $rows = array_slice($rows, 0, $step);
+                }
+
+                $result->batch = $maxBatch;
+                $rolled = [];
+                foreach ($rows as $row) {
+                    $this->restorePinnedConnection();
+                    $name = $row['version'];
+                    $migration = $this->discoverer->load($name);
+                    $this->executor->applyDown($migration, $name);
+                    $rolled[] = $name;
+                }
+
+                $result->rolledBack = $rolled;
+                $status = $this->status();
+                $result->applied = $status->applied;
+                $result->pending = $status->pending;
+                $success = true;
+                return $result;
+            });
+        } catch (Throwable $e) {
+            $success = false;
+            throw $e;
+        } finally {
+            $this->lock->release($success);
+            $this->endPinnedRun();
+        }
+    }
+
+    private function beginPinnedRun(): void
+    {
+        if (!$this->xpdo->connect(null, [xPDO::OPT_CONN_MUTABLE => true])) {
+            throw new MigrationException('Could not obtain a mutable database connection');
+        }
+        $this->pinnedConnection = $this->xpdo->connection;
+        $this->pinnedPdo = $this->xpdo->pdo;
+        if (!($this->pinnedConnection instanceof xPDOConnection) || !($this->pinnedPdo instanceof \PDO)) {
+            throw new MigrationException('Could not pin a mutable PDO connection for migrations');
+        }
+    }
+
+    private function restorePinnedConnection(): void
+    {
+        if ($this->pinnedConnection instanceof xPDOConnection) {
+            $this->xpdo->connection = $this->pinnedConnection;
+            $this->xpdo->pdo = $this->pinnedPdo;
+        }
+    }
+
+    private function endPinnedRun(): void
+    {
+        $this->restorePinnedConnection();
+        $this->pinnedConnection = null;
+        $this->pinnedPdo = null;
+    }
+
+    private function withAutoCreateDisabled(callable $fn)
+    {
+        $this->previousAutoCreate = $this->xpdo->getOption(xPDO::OPT_AUTO_CREATE_TABLES);
+        $this->xpdo->setOption(xPDO::OPT_AUTO_CREATE_TABLES, false);
+        try {
+            return $fn();
+        } finally {
+            $this->xpdo->setOption(xPDO::OPT_AUTO_CREATE_TABLES, $this->previousAutoCreate);
+        }
+    }
+
+    private function resolveLogger(xPDO $xpdo): LoggerInterface
+    {
+        if ($xpdo->logger instanceof LoggerInterface && !($xpdo->logger instanceof \xPDO\Logging\xPDOLogger)) {
+            return $xpdo->logger;
+        }
+        return new MigrationPsrLogger($xpdo);
+    }
+}

--- a/src/xPDO/Migrations/MigratorResult.php
+++ b/src/xPDO/Migrations/MigratorResult.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Migrations;
+
+final class MigratorResult
+{
+    public const REPOSITORY_OK = 'ok';
+    public const REPOSITORY_MISSING = 'missing';
+
+    /** @var string */
+    public $repositoryState;
+
+    /** @var string[] */
+    public $applied = [];
+
+    /** @var string[] */
+    public $pending = [];
+
+    /** @var string[] applied versions with missing files */
+    public $orphaned = [];
+
+    /** @var int|null */
+    public $batch = null;
+
+    /** @var string[] */
+    public $rolledBack = [];
+
+    /** @var string|null */
+    public $created = null;
+
+    /** @var string[] */
+    public $messages = [];
+
+    public function __construct(string $repositoryState = self::REPOSITORY_OK)
+    {
+        $this->repositoryState = $repositoryState;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'repository' => $this->repositoryState,
+            'applied' => $this->applied,
+            'pending' => $this->pending,
+            'orphaned' => $this->orphaned,
+            'batch' => $this->batch,
+            'rolledBack' => $this->rolledBack,
+            'created' => $this->created,
+            'messages' => $this->messages,
+        ];
+    }
+}

--- a/src/xPDO/Migrations/MigratorResult.php
+++ b/src/xPDO/Migrations/MigratorResult.php
@@ -11,6 +11,9 @@
 
 namespace xPDO\Migrations;
 
+/**
+ * Result DTO returned by Migrator methods. Part of the stable consumer surface.
+ */
 final class MigratorResult
 {
     public const REPOSITORY_OK = 'ok';

--- a/test/complete.phpunit.xml
+++ b/test/complete.phpunit.xml
@@ -40,6 +40,18 @@
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConfigTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationDiscovererTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryStatusTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorHappyPathTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorFailureTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorLockTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorRollbackTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorTransactionTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorConcurrencyTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationGeneratorUniquenessTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConsoleTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
         <testsuite name="Legacy">

--- a/test/mysql.phpunit.xml
+++ b/test/mysql.phpunit.xml
@@ -40,6 +40,18 @@
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConfigTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationDiscovererTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryStatusTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorHappyPathTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorFailureTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorLockTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorRollbackTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorTransactionTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorConcurrencyTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationGeneratorUniquenessTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConsoleTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
         <testsuite name="Legacy">

--- a/test/pgsql.phpunit.xml
+++ b/test/pgsql.phpunit.xml
@@ -40,6 +40,18 @@
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConfigTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationDiscovererTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryStatusTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorHappyPathTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorFailureTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorLockTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorRollbackTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorTransactionTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorConcurrencyTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationGeneratorUniquenessTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConsoleTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
     </testsuites>

--- a/test/properties.sample.inc.php
+++ b/test/properties.sample.inc.php
@@ -120,4 +120,10 @@ $properties['logLevel']= xPDO::LOG_LEVEL_INFO;
 $properties['logTarget']= php_sapi_name() === 'cli' ? 'ECHO' : 'HTML';
 //$properties['debug']= -1;
 
+/* Optional migrations CLI keys (used by migrate-* commands) */
+//$properties['migrations_path'] = __DIR__ . '/migrations';
+//$properties['migrations_namespace'] = 'App\\Migrations';
+//$properties['migrations_table'] = 'xpdo_migrations';
+//$properties['transaction_policy'] = 'non_transactional';
+
 return $properties;

--- a/test/sqlite.phpunit.xml
+++ b/test/sqlite.phpunit.xml
@@ -42,6 +42,18 @@
             <file>./xPDO/Test/Transport/xPDOVehicleTest.php</file>
             <file>./xPDO/Test/PSR4/xPDOTest.php</file>
             <file>./xPDO/Test/xPDOPsr11InitTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConfigTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationDiscovererTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryStatusTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationRepositoryTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorHappyPathTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorFailureTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorLockTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorRollbackTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorTransactionTest.php</file>
+            <file>./xPDO/Test/Migrations/MigratorConcurrencyTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationGeneratorUniquenessTest.php</file>
+            <file>./xPDO/Test/Migrations/MigrationConsoleTest.php</file>
             <file>./xPDO/Test/TearDownTest.php</file>
         </testsuite>
         <testsuite name="Legacy">

--- a/test/xPDO/Test/Migrations/MigrationConfigTest.php
+++ b/test/xPDO/Test/Migrations/MigrationConfigTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\Exception\ConfigurationException;
+use xPDO\Migrations\MigrationConfig;
+
+class MigrationConfigTest extends MigrationTestCase
+{
+    public function testInvalidTableNameRejected()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->makeConfig(['migrations_table' => 'xpdo_migrations;drop']);
+    }
+
+    public function testRemotePathRejected()
+    {
+        $this->expectException(ConfigurationException::class);
+        MigrationConfig::fromArray([
+            'migrations_path' => 'phar://archive.phar/migrations',
+            'migrations_namespace' => 'App\\Migrations',
+        ]);
+    }
+}

--- a/test/xPDO/Test/Migrations/MigrationConsoleTest.php
+++ b/test/xPDO/Test/Migrations/MigrationConsoleTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use xPDO\Console\Application;
+use xPDO\xPDO;
+
+class MigrationConsoleTest extends MigrationTestCase
+{
+    /** @var string */
+    private $cliConfigFile;
+
+    /** @var string */
+    private $cliSqlitePath;
+
+    /**
+     * @before
+     */
+    public function setUpCliConfig()
+    {
+        $this->cliSqlitePath = sys_get_temp_dir() . '/xpdo_cli_mig_' . uniqid('', true) . '.sqlite';
+        $driver = self::$properties['xpdo_driver'];
+        if ($driver !== 'sqlite') {
+            $this->markTestSkipped('CLI migration integration tests run on sqlite only');
+        }
+
+        $options = self::$properties['sqlite_array_options'];
+        $options[xPDO::OPT_CONNECTIONS] = [
+            [
+                'dsn' => 'sqlite:' . $this->cliSqlitePath,
+                'username' => '',
+                'password' => '',
+                'options' => [
+                    xPDO::OPT_CONN_MUTABLE => true,
+                ],
+                'driverOptions' => self::$properties['sqlite_array_driverOptions'],
+            ],
+        ];
+
+        $config = [
+            'xpdo_driver' => 'sqlite',
+            'sqlite_array_options' => $options,
+            'migrations_path' => $this->migrationsDir,
+            'migrations_namespace' => $this->migrationsNamespace,
+            'migrations_table' => $this->migrationsTable,
+        ];
+
+        $this->cliConfigFile = sys_get_temp_dir() . '/xpdo_cli_cfg_' . uniqid('', true) . '.php';
+        $export = var_export($config, true);
+        file_put_contents($this->cliConfigFile, "<?php\nuse xPDO\\xPDO;\nreturn {$export};\n");
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownCliConfig()
+    {
+        if ($this->cliConfigFile && is_file($this->cliConfigFile)) {
+            @unlink($this->cliConfigFile);
+        }
+        if ($this->cliSqlitePath && is_file($this->cliSqlitePath)) {
+            @unlink($this->cliSqlitePath);
+        }
+    }
+
+    public function testMigrateCreateStatusMigrateRollbackViaCli()
+    {
+        $create = $this->tester('migrate-create');
+        $exit = $create->execute([
+            'description' => 'CreateCliTable',
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+        ]);
+        $this->assertSame(0, $exit, $create->getDisplay());
+        $display = $create->getDisplay();
+        $this->assertStringContainsString('Created migration:', $display);
+        $this->assertMatchesRegularExpression('/[0-9]{14}_CreateCliTable/', $display);
+
+        $files = glob($this->migrationsDir . '/*_CreateCliTable.php');
+        $this->assertCount(1, $files);
+
+        // Replace stub with a real up/down against a side table name encoded in the migration.
+        $name = basename($files[0], '.php');
+        $side = $this->sideTable();
+        $this->writeMigration(
+            $name,
+            "\$xpdo = \$context->getXpdo();\n        \$t = \$xpdo->escape('{$side}');\n        \$xpdo->{'exec'}(\"CREATE TABLE {\$t} (id INTEGER PRIMARY KEY, note TEXT NOT NULL)\");",
+            "\$xpdo = \$context->getXpdo();\n        \$t = \$xpdo->escape('{$side}');\n        \$xpdo->{'exec'}(\"DROP TABLE IF EXISTS {\$t}\");"
+        );
+
+        $statusMissing = $this->tester('migrate-status');
+        $exit = $statusMissing->execute([
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+        ]);
+        $this->assertSame(0, $exit, $statusMissing->getDisplay());
+        $this->assertStringContainsString('Repository: missing', $statusMissing->getDisplay());
+
+        $migrate = $this->tester('migrate');
+        $exit = $migrate->execute([
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+        ]);
+        $this->assertSame(0, $exit, $migrate->getDisplay());
+        $this->assertStringContainsString('Applied batch', $migrate->getDisplay());
+
+        $statusOk = $this->tester('migrate-status');
+        $exit = $statusOk->execute([
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+        ]);
+        $this->assertSame(0, $exit, $statusOk->getDisplay());
+        $out = $statusOk->getDisplay();
+        $this->assertStringContainsString('Repository: ok', $out);
+        $this->assertStringContainsString($name, $out);
+        $this->assertStringContainsString('Pending:', $out);
+
+        $rollback = $this->tester('migrate-rollback');
+        $exit = $rollback->execute([
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+        ]);
+        $this->assertSame(0, $exit, $rollback->getDisplay());
+        $this->assertStringContainsString('Rolled back batch', $rollback->getDisplay());
+    }
+
+    public function testMigrateCreateHelpDefinitionAndInvalidDescription()
+    {
+        $application = new Application();
+        $application->loadCommands();
+        $command = $application->find('migrate-create');
+        $this->assertSame('migrate-create', $command->getName());
+        $this->assertNotEmpty($command->getDescription());
+        $this->assertTrue($command->getDefinition()->hasArgument('description'));
+        $this->assertTrue($command->getDefinition()->hasOption('config'));
+
+        $bad = $this->tester('migrate-create');
+        $exit = $bad->execute([
+            'description' => '9Bad',
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+        ]);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('fatal:', $bad->getDisplay());
+        $this->assertStringNotContainsString('#0 ', $bad->getDisplay());
+    }
+
+    public function testMigrateRejectsInvalidStep()
+    {
+        $migrate = $this->tester('migrate');
+        $exit = $migrate->execute([
+            '--config' => $this->cliConfigFile,
+            '--platform' => 'sqlite',
+            '--step' => '0',
+        ]);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('fatal:', $migrate->getDisplay());
+        $this->assertStringContainsString('--step', $migrate->getDisplay());
+    }
+
+    public function testMigrateFailsWithoutMigrationsPath()
+    {
+        $driver = self::$properties['xpdo_driver'];
+        if ($driver !== 'sqlite') {
+            $this->markTestSkipped('CLI negative-path test runs on sqlite only');
+        }
+        $options = self::$properties['sqlite_array_options'];
+        $options[xPDO::OPT_CONNECTIONS] = [
+            [
+                'dsn' => 'sqlite:' . $this->cliSqlitePath,
+                'username' => '',
+                'password' => '',
+                'options' => [xPDO::OPT_CONN_MUTABLE => true],
+                'driverOptions' => self::$properties['sqlite_array_driverOptions'],
+            ],
+        ];
+        $config = [
+            'xpdo_driver' => 'sqlite',
+            'sqlite_array_options' => $options,
+            // migrations_path intentionally omitted
+            'migrations_namespace' => $this->migrationsNamespace,
+            'migrations_table' => $this->migrationsTable,
+        ];
+        $badConfig = sys_get_temp_dir() . '/xpdo_cli_bad_' . uniqid('', true) . '.php';
+        $export = var_export($config, true);
+        file_put_contents($badConfig, "<?php\nuse xPDO\\xPDO;\nreturn {$export};\n");
+        try {
+            $status = $this->tester('migrate-status');
+            $exit = $status->execute([
+                '--config' => $badConfig,
+                '--platform' => 'sqlite',
+            ]);
+            $this->assertSame(1, $exit);
+            $this->assertStringContainsString('fatal:', $status->getDisplay());
+            $this->assertStringContainsString('migrations_path', $status->getDisplay());
+        } finally {
+            @unlink($badConfig);
+        }
+    }
+
+    private function tester(string $commandName): CommandTester
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->loadCommands();
+        return new CommandTester($application->find($commandName));
+    }
+}

--- a/test/xPDO/Test/Migrations/MigrationDiscovererTest.php
+++ b/test/xPDO/Test/Migrations/MigrationDiscovererTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\Exception\InvalidMigrationException;
+use xPDO\Migrations\Migration;
+use xPDO\Migrations\MigrationDiscoverer;
+
+class MigrationDiscovererTest extends MigrationTestCase
+{
+    public function testValidMigrationLoads()
+    {
+        $name = '20260103110000_ValidOne';
+        $this->writeMigration($name);
+        $discoverer = new MigrationDiscoverer($this->makeConfig());
+        $migration = $discoverer->load($name);
+        $this->assertInstanceOf(Migration::class, $migration);
+    }
+
+    public function testInvalidClassFailsLoad()
+    {
+        $name = '20260103120000_Broken';
+        $file = $this->migrationsDir . '/' . $name . '.php';
+        file_put_contents($file, "<?php\nnamespace {$this->migrationsNamespace};\nclass M{$name} {}\n");
+
+        $discoverer = new MigrationDiscoverer($this->makeConfig());
+        $this->expectException(InvalidMigrationException::class);
+        $discoverer->load($name);
+    }
+
+    public function testDiscoverIgnoresNonMatchingFilesAndOrdersByName()
+    {
+        file_put_contents($this->migrationsDir . '/readme.php', "<?php\n");
+        file_put_contents($this->migrationsDir . '/20260103120100_bad-name.php', "<?php\n");
+        $subdir = $this->migrationsDir . '/subdir';
+        mkdir($subdir);
+        file_put_contents($subdir . '/20260103120300_Nested.php', "<?php\n");
+
+        $this->writeMigration('20260103120200_Second');
+        $this->writeMigration('20260103120100_First');
+
+        try {
+            $discoverer = new MigrationDiscoverer($this->makeConfig());
+            $found = $discoverer->discover();
+            $this->assertSame(
+                ['20260103120100_First', '20260103120200_Second'],
+                array_column($found, 'name')
+            );
+        } finally {
+            @unlink($subdir . '/20260103120300_Nested.php');
+            @rmdir($subdir);
+        }
+    }
+
+    public function testLoadMissingFileFails()
+    {
+        $discoverer = new MigrationDiscoverer($this->makeConfig());
+        $this->expectException(InvalidMigrationException::class);
+        $discoverer->load('20260103129900_Missing');
+    }
+
+    public function testLoadInvalidNameFails()
+    {
+        $discoverer = new MigrationDiscoverer($this->makeConfig());
+        $this->expectException(InvalidMigrationException::class);
+        $discoverer->load('not-a-valid-name');
+    }
+}

--- a/test/xPDO/Test/Migrations/MigrationGeneratorUniquenessTest.php
+++ b/test/xPDO/Test/Migrations/MigrationGeneratorUniquenessTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use xPDO\Migrations\Exception\ConfigurationException;
+use xPDO\Migrations\MigrationGenerator;
+
+class MigrationGeneratorUniquenessTest extends MigrationTestCase
+{
+    public function testCreateWritesStubWithExpectedClassName()
+    {
+        $generator = new MigrationGenerator($this->makeConfig());
+        $name = $generator->create('CreateWidgetTable');
+
+        $this->assertMatchesRegularExpression('/^[0-9]{14}_CreateWidgetTable$/', $name);
+        $path = $this->migrationsDir . '/' . $name . '.php';
+        $this->assertFileExists($path);
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString('namespace ' . $this->migrationsNamespace . ';', $contents);
+        $this->assertStringContainsString('class M' . $name . ' extends Migration', $contents);
+    }
+
+    public function testCreateSkipsOccupiedTimestampInsteadOfOverwrite()
+    {
+        $generator = new MigrationGenerator($this->makeConfig());
+        $dt = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $occupied = $dt->format('YmdHis') . '_SameSecond';
+        file_put_contents($this->migrationsDir . '/' . $occupied . '.php', "<?php // occupied\n");
+
+        $name = $generator->create('SameSecond');
+        $this->assertNotSame($occupied, $name);
+        $this->assertMatchesRegularExpression('/^[0-9]{14}_SameSecond$/', $name);
+        $this->assertFileExists($this->migrationsDir . '/' . $name . '.php');
+        $this->assertSame(
+            "<?php // occupied\n",
+            file_get_contents($this->migrationsDir . '/' . $occupied . '.php')
+        );
+    }
+
+    public function testCreateRejectsInvalidDescription()
+    {
+        $generator = new MigrationGenerator($this->makeConfig());
+        $this->expectException(ConfigurationException::class);
+        $generator->create('123Invalid');
+    }
+}

--- a/test/xPDO/Test/Migrations/MigrationRepositoryStatusTest.php
+++ b/test/xPDO/Test/Migrations/MigrationRepositoryStatusTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\MigrationRepository;
+use xPDO\Migrations\MigratorResult;
+
+class MigrationRepositoryStatusTest extends MigrationTestCase
+{
+    public function testStatusDoesNotCreateRepository()
+    {
+        $migrator = $this->makeMigrator();
+        $status = $migrator->status();
+        $this->assertSame(MigratorResult::REPOSITORY_MISSING, $status->repositoryState);
+
+        $repo = new MigrationRepository($this->xpdo, $this->makeConfig());
+        $this->assertFalse($repo->exists());
+    }
+}

--- a/test/xPDO/Test/Migrations/MigrationRepositoryTest.php
+++ b/test/xPDO/Test/Migrations/MigrationRepositoryTest.php
@@ -80,4 +80,16 @@ class MigrationRepositoryTest extends MigrationTestCase
         $this->assertSame([$orphan], $status->orphaned);
         $this->assertSame([], $status->pending);
     }
+
+    public function testDuplicateVersionInsertFails()
+    {
+        $repo = new MigrationRepository($this->xpdo, $this->makeConfig());
+        $repo->ensure();
+        $version = '20260403120000_Dup';
+        $at = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $repo->insert($version, 1, $at);
+
+        $this->expectException(\xPDO\Migrations\Exception\MigrationException::class);
+        $repo->insert($version, 2, $at);
+    }
 }

--- a/test/xPDO/Test/Migrations/MigrationRepositoryTest.php
+++ b/test/xPDO/Test/Migrations/MigrationRepositoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use xPDO\Migrations\MigrationRepository;
+use xPDO\Migrations\MigratorResult;
+
+class MigrationRepositoryTest extends MigrationTestCase
+{
+    public function testEnsureInsertQueryBatchAndPendingViaStatus()
+    {
+        $repo = new MigrationRepository($this->xpdo, $this->makeConfig());
+        $this->assertFalse($repo->exists());
+
+        $repo->ensure();
+        $this->assertTrue($repo->exists());
+        $this->assertSame(0, $repo->maxBatch());
+        $this->assertSame(1, $repo->nextBatch());
+        $this->assertSame([], $repo->fetchAppliedVersions());
+
+        $v1 = '20260401120000_Alpha';
+        $v2 = '20260401120100_Beta';
+        $this->writeMigration($v1);
+        $this->writeMigration($v2);
+
+        $at = new DateTimeImmutable('2026-04-01 12:00:00', new DateTimeZone('UTC'));
+        $batch = $repo->nextBatch();
+        $this->assertSame(1, $batch);
+        $repo->insert($v1, $batch, $at);
+        $repo->insert($v2, $batch, $at->modify('+1 minute'));
+
+        $this->assertSame([$v1, $v2], $repo->fetchAppliedVersions());
+        $this->assertSame(1, $repo->maxBatch());
+        $this->assertSame(2, $repo->nextBatch());
+
+        $rows = $repo->fetchByBatch(1);
+        $this->assertCount(2, $rows);
+        $this->assertSame($v2, $rows[0]['version']);
+        $this->assertSame($v1, $rows[1]['version']);
+        $this->assertSame(1, $rows[0]['batch']);
+
+        $migrator = $this->makeMigrator();
+        $status = $migrator->status();
+        $this->assertSame(MigratorResult::REPOSITORY_OK, $status->repositoryState);
+        $this->assertSame([$v1, $v2], $status->applied);
+        $this->assertSame([], $status->pending);
+
+        $v3 = '20260401120200_Gamma';
+        $this->writeMigration($v3);
+        $status = $migrator->status();
+        $this->assertSame([$v3], $status->pending);
+
+        $repo->delete($v2);
+        $this->assertSame([$v1], $repo->fetchAppliedVersions());
+        $status = $migrator->status();
+        $this->assertSame([$v1], $status->applied);
+        $this->assertSame([$v2, $v3], $status->pending);
+    }
+
+    public function testStatusReportsOrphanedLedgerRows()
+    {
+        $repo = new MigrationRepository($this->xpdo, $this->makeConfig());
+        $repo->ensure();
+        $orphan = '20260402120000_Orphan';
+        $repo->insert($orphan, 1, new DateTimeImmutable('now', new DateTimeZone('UTC')));
+
+        $status = $this->makeMigrator()->status();
+        $this->assertSame([$orphan], $status->applied);
+        $this->assertSame([$orphan], $status->orphaned);
+        $this->assertSame([], $status->pending);
+    }
+}

--- a/test/xPDO/Test/Migrations/MigrationTestCase.php
+++ b/test/xPDO/Test/Migrations/MigrationTestCase.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\MigrationConfig;
+use xPDO\Migrations\Migrator;
+use xPDO\TestCase;
+
+abstract class MigrationTestCase extends TestCase
+{
+    /** @var string */
+    protected $migrationsDir;
+
+    /** @var string */
+    protected $migrationsTable;
+
+    /** @var string */
+    protected $migrationsNamespace = 'xPDO\\Test\\Migrations\\Fixture';
+
+    /**
+     * @before
+     */
+    public function setUpMigrationFixtures()
+    {
+        $this->migrationsDir = sys_get_temp_dir() . '/xpdo_migrations_' . uniqid('', true);
+        mkdir($this->migrationsDir, 0777, true);
+        $this->migrationsTable = 'xpdo_mig_' . substr(md5(uniqid('', true)), 0, 8);
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownMigrationFixtures()
+    {
+        if ($this->xpdo && $this->migrationsTable) {
+            $this->dropSideTable();
+            try {
+                $escaped = $this->xpdo->escape($this->migrationsTable);
+                $this->xpdo->{'exec'}("DROP TABLE IF EXISTS {$escaped}");
+            } catch (\Throwable $e) {
+                // ignore
+            }
+        }
+        if ($this->migrationsDir && is_dir($this->migrationsDir)) {
+            foreach (glob($this->migrationsDir . '/*') ?: [] as $file) {
+                @unlink($file);
+            }
+            @rmdir($this->migrationsDir);
+        }
+    }
+
+    protected function makeConfig(array $overrides = []): MigrationConfig
+    {
+        return MigrationConfig::fromArray(array_merge([
+            'migrations_path' => $this->migrationsDir,
+            'migrations_namespace' => $this->migrationsNamespace,
+            'migrations_table' => $this->migrationsTable,
+            'transaction_policy' => MigrationConfig::POLICY_NON_TRANSACTIONAL,
+        ], $overrides));
+    }
+
+    protected function makeMigrator(array $configOverrides = []): Migrator
+    {
+        return new Migrator($this->xpdo, $this->makeConfig($configOverrides));
+    }
+
+    /**
+     * Second xPDO instance with its own PDO session (same DSN/options).
+     */
+    protected function makeSecondaryXpdo(): \xPDO\xPDO
+    {
+        $driver = self::$properties['xpdo_driver'];
+        $options = self::$properties["{$driver}_array_options"];
+        $name = 'migrations_secondary_' . str_replace('.', '', uniqid('', true));
+        $xpdo = \xPDO\xPDO::getInstance($name, $options);
+        $this->assertInstanceOf(\xPDO\xPDO::class, $xpdo);
+        $xpdo->setLogLevel(\xPDO\xPDO::LOG_LEVEL_ERROR);
+        $xpdo->setLogTarget('ECHO');
+        return $xpdo;
+    }
+
+    protected function writeMigration(
+        string $name,
+        string $upBody = '',
+        string $downBody = '',
+        ?bool $transactional = null
+    ): string {
+        $class = 'M' . $name;
+        $upBody = $upBody !== '' ? $upBody : '// no-op';
+        $downBody = $downBody !== '' ? $downBody : '// no-op';
+        $txnMethod = '';
+        if ($transactional !== null) {
+            $val = $transactional ? 'true' : 'false';
+            $txnMethod = <<<PHP
+
+    public function isTransactional(): ?bool
+    {
+        return {$val};
+    }
+PHP;
+        }
+        $code = <<<PHP
+<?php
+namespace {$this->migrationsNamespace};
+
+use xPDO\\Migrations\\Migration;
+use xPDO\\Migrations\\MigrationContext;
+
+class {$class} extends Migration
+{
+    public function up(MigrationContext \$context): void
+    {
+        {$upBody}
+    }
+
+    public function down(MigrationContext \$context): void
+    {
+        {$downBody}
+    }
+{$txnMethod}
+}
+PHP;
+        $file = $this->migrationsDir . '/' . $name . '.php';
+        file_put_contents($file, $code);
+        return $file;
+    }
+
+    protected function sideTable(): string
+    {
+        return $this->migrationsTable . '_side';
+    }
+
+    protected function ensureSideTable(): void
+    {
+        $table = $this->xpdo->escape($this->sideTable());
+        $dbtype = $this->xpdo->getOption('dbtype');
+        if ($dbtype === 'pgsql') {
+            $sql = "CREATE TABLE IF NOT EXISTS {$table} (id INTEGER PRIMARY KEY, note VARCHAR(64) NOT NULL)";
+        } elseif ($dbtype === 'sqlite') {
+            $sql = "CREATE TABLE IF NOT EXISTS {$table} (id INTEGER PRIMARY KEY, note TEXT NOT NULL)";
+        } else {
+            $sql = "CREATE TABLE IF NOT EXISTS {$table} (id INT NOT NULL PRIMARY KEY, note VARCHAR(64) NOT NULL) DEFAULT CHARSET=utf8mb4";
+        }
+        $this->xpdo->{'exec'}($sql);
+    }
+
+    protected function dropSideTable(): void
+    {
+        if (!$this->xpdo) {
+            return;
+        }
+        $table = $this->xpdo->escape($this->sideTable());
+        try {
+            $this->xpdo->{'exec'}("DROP TABLE IF EXISTS {$table}");
+        } catch (\Throwable $e) {
+            // ignore
+        }
+    }
+}

--- a/test/xPDO/Test/Migrations/MigratorConcurrencyTest.php
+++ b/test/xPDO/Test/Migrations/MigratorConcurrencyTest.php
@@ -30,7 +30,7 @@ class MigratorConcurrencyTest extends MigrationTestCase
             $this->expectException(MigrationLockedException::class);
             $migrator->migrate();
         } finally {
-            $lock->release(true);
+            $lock->release();
             $secondary->pdo = null;
         }
     }

--- a/test/xPDO/Test/Migrations/MigratorConcurrencyTest.php
+++ b/test/xPDO/Test/Migrations/MigratorConcurrencyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\Exception\MigrationLockedException;
+use xPDO\Migrations\MigrationLock;
+use xPDO\Migrations\Migrator;
+
+class MigratorConcurrencyTest extends MigrationTestCase
+{
+    public function testMigrateFailsWhenLockHeldOnSecondSession()
+    {
+        $this->writeMigration('20260303120000_Locked');
+        $config = $this->makeConfig();
+        $secondary = $this->makeSecondaryXpdo();
+        $lock = new MigrationLock($secondary, $config);
+        $lock->acquire();
+
+        try {
+            $migrator = new Migrator($this->xpdo, $config);
+            $this->expectException(MigrationLockedException::class);
+            $migrator->migrate();
+        } finally {
+            $lock->release(true);
+            $secondary->pdo = null;
+        }
+    }
+}

--- a/test/xPDO/Test/Migrations/MigratorFailureTest.php
+++ b/test/xPDO/Test/Migrations/MigratorFailureTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\Migrations\MigratorResult;
+
+class MigratorFailureTest extends MigrationTestCase
+{
+    public function testFailedUpDoesNotRecordAndStopsBatch()
+    {
+        $ok = '20260102120000_OkOne';
+        $bad = '20260102120100_BadTwo';
+        $later = '20260102120200_LaterThree';
+
+        $this->writeMigration($ok);
+        $this->writeMigration($bad, 'throw new \\RuntimeException("boom");');
+        $this->writeMigration($later);
+
+        $migrator = $this->makeMigrator();
+
+        try {
+            $migrator->migrate();
+            $this->fail('Expected MigrationException');
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString('boom', $e->getMessage());
+            $this->assertStringContainsString('20260102120100_BadTwo', $e->getMessage());
+            $this->assertStringContainsString('up', $e->getMessage());
+        }
+
+        $status = $migrator->status();
+        $this->assertSame(MigratorResult::REPOSITORY_OK, $status->repositoryState);
+        $this->assertSame([$ok], $status->applied);
+        $this->assertSame([$bad, $later], $status->pending);
+    }
+}

--- a/test/xPDO/Test/Migrations/MigratorHappyPathTest.php
+++ b/test/xPDO/Test/Migrations/MigratorHappyPathTest.php
@@ -88,4 +88,16 @@ class MigratorHappyPathTest extends MigrationTestCase
 
         $this->assertSame($pdoBefore, $this->xpdo->pdo);
     }
+
+    public function testLedgerWriteSurvivesUpClearingConnection()
+    {
+        $name = '20260101122100_PinRestore';
+        $this->writeMigration(
+            $name,
+            '$xpdo = $context->getXpdo(); $xpdo->pdo = null; $xpdo->connection = null;'
+        );
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+        $this->assertSame([$name], $migrator->status()->applied);
+    }
 }

--- a/test/xPDO/Test/Migrations/MigratorHappyPathTest.php
+++ b/test/xPDO/Test/Migrations/MigratorHappyPathTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\MigratorResult;
+
+class MigratorHappyPathTest extends MigrationTestCase
+{
+    public function testEmptyMigrationSetSucceeds()
+    {
+        $migrator = $this->makeMigrator();
+        $result = $migrator->migrate();
+        $this->assertSame(MigratorResult::REPOSITORY_OK, $result->repositoryState);
+        $this->assertSame([], $result->applied);
+        $this->assertSame([], $result->pending);
+        $this->assertNull($result->batch);
+    }
+
+    public function testSingleMigrationMigrate()
+    {
+        $name = '20260101115900_OnlyOne';
+        $this->writeMigration($name);
+        $migrator = $this->makeMigrator();
+        $result = $migrator->migrate();
+        $this->assertSame([$name], $result->applied);
+        $this->assertSame(1, $result->batch);
+        $this->assertSame([$name], $migrator->status()->applied);
+    }
+
+    public function testDiscoverPendingMigrateAndStatus()
+    {
+        $m1 = '20260101120000_CreateAlpha';
+        $m2 = '20260101120100_CreateBeta';
+        $this->writeMigration($m1);
+        $this->writeMigration($m2);
+
+        $migrator = $this->makeMigrator();
+
+        $beforeEnsure = $migrator->status();
+        $this->assertSame(MigratorResult::REPOSITORY_MISSING, $beforeEnsure->repositoryState);
+
+        $result = $migrator->migrate();
+        $this->assertSame(MigratorResult::REPOSITORY_OK, $result->repositoryState);
+        $this->assertSame([$m1, $m2], $result->applied);
+        $this->assertSame([], $result->pending);
+        $this->assertSame(1, $result->batch);
+
+        $status = $migrator->status();
+        $this->assertSame(MigratorResult::REPOSITORY_OK, $status->repositoryState);
+        $this->assertSame([$m1, $m2], $status->applied);
+        $this->assertSame([], $status->pending);
+
+        $again = $migrator->migrate();
+        $this->assertSame([], $again->applied);
+        $this->assertSame([], $again->pending);
+    }
+
+    public function testMigrateStepAppliesSubset()
+    {
+        $m1 = '20260101121000_StepA';
+        $m2 = '20260101121100_StepB';
+        $this->writeMigration($m1);
+        $this->writeMigration($m2);
+        $migrator = $this->makeMigrator();
+
+        $result = $migrator->migrate(1);
+        $this->assertSame([$m1], $result->applied);
+        $this->assertSame([$m2], $result->pending);
+    }
+
+    public function testMigrateKeepsPinnedPdoIdentity()
+    {
+        $this->writeMigration('20260101122000_Pin');
+        $this->assertTrue($this->xpdo->connect(null, [\xPDO\xPDO::OPT_CONN_MUTABLE => true]));
+        $pdoBefore = $this->xpdo->pdo;
+        $this->assertInstanceOf(\PDO::class, $pdoBefore);
+
+        $this->makeMigrator()->migrate();
+
+        $this->assertSame($pdoBefore, $this->xpdo->pdo);
+    }
+}

--- a/test/xPDO/Test/Migrations/MigratorLockTest.php
+++ b/test/xPDO/Test/Migrations/MigratorLockTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\Migrations\Exception\MigrationLockedException;
+use xPDO\Migrations\MigrationLock;
+use xPDO\Migrations\Migrator;
+
+class MigratorLockTest extends MigrationTestCase
+{
+    public function testSecondSessionCannotAcquireLock()
+    {
+        $config = $this->makeConfig();
+        $secondary = $this->makeSecondaryXpdo();
+        $lockSecondary = new MigrationLock($secondary, $config);
+        $lockSecondary->acquire();
+
+        try {
+            $this->writeMigration('20260305120000_BlockedByOtherSession');
+            $migrator = new Migrator($this->xpdo, $config);
+            $this->expectException(MigrationLockedException::class);
+            $migrator->migrate();
+        } finally {
+            $lockSecondary->release(true);
+            $secondary->pdo = null;
+        }
+    }
+
+    public function testSameSessionSecondLockIsReentrantOrFailsFast()
+    {
+        $config = $this->makeConfig();
+        $lockA = new MigrationLock($this->xpdo, $config);
+        $lockA->acquire();
+
+        try {
+            $lockB = new MigrationLock($this->xpdo, $config);
+            try {
+                $lockB->acquire();
+                // mysql/pgsql advisory locks reenter on the same session; sqlite flock may not.
+                $this->assertTrue(true);
+            } catch (MigrationLockedException $e) {
+                $this->assertInstanceOf(MigrationLockedException::class, $e);
+            }
+        } finally {
+            $lockA->release(true);
+        }
+    }
+
+    public function testLockReleasedAfterFailedMigrateAllowsRetry()
+    {
+        $name = '20260304120000_FailThenRetry';
+        $this->writeMigration($name, 'throw new \\RuntimeException("lock-release-boom");');
+        $migrator = $this->makeMigrator();
+
+        try {
+            $migrator->migrate();
+            $this->fail('Expected MigrationException');
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString('lock-release-boom', $e->getMessage());
+        }
+
+        try {
+            $migrator->migrate();
+            $this->fail('Expected MigrationException from migration body, not lock');
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString('lock-release-boom', $e->getMessage());
+            $this->assertStringNotContainsString('Could not acquire migration lock', $e->getMessage());
+        }
+    }
+
+    public function testSqliteLockHeldBlocksSecondProcess()
+    {
+        if ($this->xpdo->getOption('dbtype') !== 'sqlite') {
+            $this->markTestSkipped('Cross-process flock contention is asserted for sqlite only');
+        }
+
+        $config = $this->makeConfig();
+        $lock = new MigrationLock($this->xpdo, $config);
+        $lock->acquire();
+        $lockFile = $this->migrationsDir . DIRECTORY_SEPARATOR . '.xpdo_migration.lock';
+        $this->assertFileExists($lockFile);
+
+        $script = '<?php
+$h = fopen(' . var_export($lockFile, true) . ', "c+");
+if ($h === false) { fwrite(STDERR, "open-fail\n"); exit(2); }
+if (!flock($h, LOCK_EX | LOCK_NB)) { exit(0); }
+flock($h, LOCK_UN);
+fclose($h);
+exit(1);
+';
+        $tmp = tempnam(sys_get_temp_dir(), 'xpdo_lock_');
+        file_put_contents($tmp, $script);
+
+        try {
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+            $process = proc_open(
+                [PHP_BINARY, $tmp],
+                $descriptors,
+                $pipes,
+                null,
+                null,
+                ['bypass_shell' => true]
+            );
+            $this->assertIsResource($process);
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $code = proc_close($process);
+            $this->assertSame(
+                0,
+                $code,
+                'Second process must fail to acquire flock while migrator holds it; stdout='
+                . $stdout . ' stderr=' . $stderr
+            );
+        } finally {
+            $lock->release(true);
+            @unlink($tmp);
+        }
+    }
+}

--- a/test/xPDO/Test/Migrations/MigratorLockTest.php
+++ b/test/xPDO/Test/Migrations/MigratorLockTest.php
@@ -129,7 +129,7 @@ exit(1);
                 . $stdout . ' stderr=' . $stderr
             );
         } finally {
-            $lock->release(true);
+            $lock->release();
             @unlink($tmp);
         }
     }

--- a/test/xPDO/Test/Migrations/MigratorRollbackTest.php
+++ b/test/xPDO/Test/Migrations/MigratorRollbackTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use xPDO\Migrations\Exception\IrreversibleMigrationException;
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\Migrations\MigratorResult;
+
+class MigratorRollbackTest extends MigrationTestCase
+{
+    public function testSuccessfulRollbackRestoresPending()
+    {
+        $m1 = '20260201120000_One';
+        $m2 = '20260201120100_Two';
+        $this->writeMigration($m1);
+        $this->writeMigration($m2);
+
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+
+        $rolled = $migrator->rollback();
+        $this->assertSame([$m2, $m1], $rolled->rolledBack);
+        $this->assertSame(1, $rolled->batch);
+
+        $status = $migrator->status();
+        $this->assertSame([], $status->applied);
+        $this->assertSame([$m1, $m2], $status->pending);
+    }
+
+    public function testRollbackOrderingIsDescendingWithinBatch()
+    {
+        $names = [
+            '20260202120000_A',
+            '20260202120100_B',
+            '20260202120200_C',
+        ];
+        $orderFile = $this->migrationsDir . '/down_order.log';
+        foreach ($names as $name) {
+            $this->writeMigration(
+                $name,
+                '',
+                'file_put_contents(' . var_export($orderFile, true) . ', ' . var_export($name, true) . ' . PHP_EOL, FILE_APPEND);'
+            );
+        }
+
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+        $migrator->rollback();
+
+        $lines = array_values(array_filter(array_map('trim', file($orderFile))));
+        $this->assertSame(array_reverse($names), $lines);
+    }
+
+    public function testRollbackStepLimitsToOne()
+    {
+        $m1 = '20260203120000_One';
+        $m2 = '20260203120100_Two';
+        $this->writeMigration($m1);
+        $this->writeMigration($m2);
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+
+        $rolled = $migrator->rollback(1);
+        $this->assertSame([$m2], $rolled->rolledBack);
+
+        $status = $migrator->status();
+        $this->assertSame([$m1], $status->applied);
+        $this->assertSame([$m2], $status->pending);
+    }
+
+    public function testFailedRollbackKeepsLedgerRow()
+    {
+        $m1 = '20260204120000_Ok';
+        $m2 = '20260204120100_BadDown';
+        $this->writeMigration($m1);
+        $this->writeMigration($m2, '', 'throw new \\RuntimeException("down-boom");');
+
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+
+        try {
+            $migrator->rollback();
+            $this->fail('Expected MigrationException');
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString('20260204120100_BadDown', $e->getMessage());
+            $this->assertStringContainsString('down', $e->getMessage());
+            $this->assertStringContainsString('down-boom', $e->getMessage());
+        }
+
+        $status = $migrator->status();
+        $this->assertSame([$m1, $m2], $status->applied);
+        $this->assertSame([], $status->pending);
+    }
+
+    public function testIrreversibleDownAbortsWithoutRemovingRow()
+    {
+        $name = '20260205120000_Forever';
+        $this->writeMigration(
+            $name,
+            '',
+            'throw new \\xPDO\\Migrations\\Exception\\IrreversibleMigrationException("nope");'
+        );
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+
+        try {
+            $migrator->rollback();
+            $this->fail('Expected IrreversibleMigrationException');
+        } catch (IrreversibleMigrationException $e) {
+            $this->assertStringContainsString('nope', $e->getMessage());
+        }
+
+        $status = $migrator->status();
+        $this->assertSame([$name], $status->applied);
+    }
+
+    public function testPartialBatchRollback()
+    {
+        $ok = '20260206120000_Ok';
+        $bad = '20260206120100_Bad';
+        $this->writeMigration($ok);
+        $this->writeMigration($bad, 'throw new \\RuntimeException("up-fail");');
+
+        $migrator = $this->makeMigrator();
+        try {
+            $migrator->migrate();
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString('up-fail', $e->getMessage());
+        }
+
+        $status = $migrator->status();
+        $this->assertSame([$ok], $status->applied);
+
+        $rolled = $migrator->rollback();
+        $this->assertSame([$ok], $rolled->rolledBack);
+        $this->assertSame([], $migrator->status()->applied);
+    }
+
+    public function testRollbackFailsWhenMigrationFileMissing()
+    {
+        $name = '20260207120000_Gone';
+        $file = $this->writeMigration($name);
+        $migrator = $this->makeMigrator();
+        $migrator->migrate();
+        $this->assertFileExists($file);
+        unlink($file);
+
+        try {
+            $migrator->rollback();
+            $this->fail('Expected MigrationException for missing migration file');
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString($name, $e->getMessage());
+        }
+
+        $status = $migrator->status();
+        $this->assertSame([$name], $status->applied);
+        $this->assertSame([$name], $status->orphaned);
+    }
+
+    public function testEmptyRollbackSucceeds()
+    {
+        $migrator = $this->makeMigrator();
+        $result = $migrator->rollback();
+        $this->assertSame([], $result->rolledBack);
+        $this->assertSame([], $result->applied);
+    }
+}

--- a/test/xPDO/Test/Migrations/MigratorTransactionTest.php
+++ b/test/xPDO/Test/Migrations/MigratorTransactionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the xPDO package.
+ *
+ * Copyright (c) Jason Coward <jason@opengeek.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace xPDO\Test\Migrations;
+
+use PDO;
+use xPDO\Migrations\Exception\MigrationException;
+use xPDO\Migrations\MigrationConfig;
+
+class MigratorTransactionTest extends MigrationTestCase
+{
+    public function testTransactionalFailureRollsBackSideEffectsAndDoesNotRecord()
+    {
+        $this->ensureSideTable();
+        $table = $this->sideTable();
+        $name = '20260301120000_TxnFail';
+
+        $this->writeMigration(
+            $name,
+            '$xpdo = $context->getXpdo();'
+            . '$stmt = $xpdo->prepare("INSERT INTO " . $xpdo->escape(' . var_export($table, true) . ') . " (id, note) VALUES (1, ?)");'
+            . '$stmt->execute(["before-fail"]);'
+            . 'throw new \\RuntimeException("txn-boom");',
+            '',
+            true
+        );
+
+        $migrator = $this->makeMigrator([
+            'transaction_policy' => MigrationConfig::POLICY_TRANSACTIONAL,
+        ]);
+
+        try {
+            $migrator->migrate();
+            $this->fail('Expected MigrationException');
+        } catch (MigrationException $e) {
+            $this->assertStringContainsString('txn-boom', $e->getMessage());
+            $this->assertStringContainsString($name, $e->getMessage());
+        }
+
+        $status = $migrator->status();
+        $this->assertSame([], $status->applied);
+        $this->assertSame([$name], $status->pending);
+
+        $escaped = $this->xpdo->escape($table);
+        $stmt = $this->xpdo->query("SELECT COUNT(*) AS c FROM {$escaped}");
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(0, (int) $row['c']);
+
+        // Driver caveat: MySQL DDL often implicit-commits; this case uses DML INSERT only.
+        $this->assertContains($this->xpdo->getOption('dbtype'), ['sqlite', 'mysql', 'pgsql', 'sqlsrv']);
+    }
+
+    public function testTransactionalSuccessCommitsSideEffectAndLedger()
+    {
+        $this->ensureSideTable();
+        $table = $this->sideTable();
+        $name = '20260302120000_TxnOk';
+
+        $this->writeMigration(
+            $name,
+            '$xpdo = $context->getXpdo();'
+            . '$stmt = $xpdo->prepare("INSERT INTO " . $xpdo->escape(' . var_export($table, true) . ') . " (id, note) VALUES (1, ?)");'
+            . '$stmt->execute(["ok"]);',
+            '$xpdo = $context->getXpdo();'
+            . '$xpdo->{\'exec\'}("DELETE FROM " . $xpdo->escape(' . var_export($table, true) . '));',
+            true
+        );
+
+        $migrator = $this->makeMigrator([
+            'transaction_policy' => MigrationConfig::POLICY_TRANSACTIONAL,
+        ]);
+        $migrator->migrate();
+
+        $this->assertSame([$name], $migrator->status()->applied);
+        $escaped = $this->xpdo->escape($table);
+        $stmt = $this->xpdo->query("SELECT note FROM {$escaped} WHERE id = 1");
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('ok', $row['note']);
+    }
+}


### PR DESCRIPTION
## Problem

xPDO has schema codegen (`parse-schema` / `write-schema`) and Transport packaging, but no ordered, ledger-backed way to apply and reverse database changes across environments. [PR #143](https://github.com/modxcms/xpdo/pull/143) (2018–2023) sketched this and closed unmerged: no tests, mysql-centric ledger maps, install-gated commands, branch gone. This PR is a new implementation for current `3.x` (PHP ≥8.1; mysql/pgsql/sqlite like existing CI), not a rebase of that diff.

## What this PR adds

- Library: `xPDO\Migrations\` with public `Migrator`, `Migration`, `MigrationContext`, `MigrationConfig`, plus `MigratorResult` DTOs.
- Ledger table (default `xpdo_migrations`): `version` (UNIQUE), `batch`, `applied_at`. Row only after successful `up()`.
- Console on existing `bin/xpdo`: `migrate-create`, `migrate-status`, `migrate`, `migrate-rollback` (always registered; hyphen names like `parse-schema`).
- Drivers: portable DDL for **mysql**, **pgsql**, **sqlite**. Adds `pgsql` to `Command::$platforms`.
- Default `transaction_policy=non_transactional` (MySQL DDL often implicit-commits; stubs and `cli.md` say so). Policy `transactional` wraps each migration’s `up`/`down` + ledger write.
- Fail-fast migrate locks; connection pin for the run (restored before ledger write); `--step` on migrate/rollback.
- Tests under `test/xPDO/Test/Migrations/`. CLI docs: `docs/migrations/cli.md`.

Out of scope (explicit): schema diff, seeds, `migrate-fresh`, sqlsrv CI gate, checksums.

## Compatibility

- Additive only. Om, Transport, and existing Console commands unchanged aside from registering migrate commands, allowing `pgsql` on `$platforms`, and `: int` on existing `ParseSchema` / `WriteSchema` `execute()` (Symfony Console 6).
- No MODX packages. Any consumer with xPDO connection config can use it.
- No new runtime Composer dependencies.

## Maintainer value

- One path for shared DB changes: migration files in git, ledger rows in the DB, same `bin/xpdo` as schema tools.
- Failed `up` is not recorded; later pending stop. You can roll back the last (including partial) batch.
- Review surface: small public API; discoverer/repository/executor/lock marked `@internal`.
- Same problem #143 aimed at, with the tests and driver coverage that PR never landed.

## Verified

| Gate | Result |
|------|--------|
| GitHub Actions (PR branch) | PHP 8.1–8.5 × sqlite/mysql/pgsql **green** |
| Local sqlite `--filter Migration` | 40 OK |

Skips on non-sqlite: sqlite-only flock process test; CLI tests skipped when `xpdo_driver` is not sqlite (harness uses a sqlite DSN).

## Example usage

```bash
php bin/xpdo migrate-create CreateWidgetTable \
  -C path/to/properties.inc.php --platform=sqlite \
  --path=./migrations --namespace='App\Migrations'

php bin/xpdo migrate-status -C path/to/properties.inc.php --platform=sqlite \
  --path=./migrations --namespace='App\Migrations'

php bin/xpdo migrate -C path/to/properties.inc.php --platform=sqlite \
  --path=./migrations --namespace='App\Migrations'

php bin/xpdo migrate --step=1 -C path/to/properties.inc.php --platform=sqlite \
  --path=./migrations --namespace='App\Migrations'

php bin/xpdo migrate-rollback -C path/to/properties.inc.php --platform=sqlite \
  --path=./migrations --namespace='App\Migrations'
```

PHP: `new Migrator($xpdo, MigrationConfig::fromArray([...]))` then `create()` / `status()` / `migrate()` / `rollback()`.

## Reviewer notes

- Public API: `Migrator`, `Migration`, `MigrationContext`, `MigrationConfig`, `MigratorResult`. Rest is `@internal`.
- Identity = filename stem `YYYYMMDDHHMMSS_Description`; ledger `version` UNIQUE.
- Default non-transactional is intentional for MySQL DDL; see Transactions in `cli.md`.
- Lock fail-fast proven with a **second PDO session** on mysql/pgsql; sqlite uses flock + second process.

## Test plan

- [x] GitHub Actions CI green (PHP 8.1–8.5 × sqlite/mysql/pgsql)
- [ ] `vendor/bin/phpunit -c ./test/sqlite.phpunit.xml --filter Migration`
- [ ] `vendor/bin/phpunit -c ./test/mysql.phpunit.xml --filter Migration`
- [ ] `vendor/bin/phpunit -c ./test/pgsql.phpunit.xml --filter Migration`
- [ ] `php bin/xpdo list` shows the four migrate-* commands
- [ ] Smoke: create → status → migrate → rollback on sqlite